### PR TITLE
Fix: Resolve column ambiguity error in combined samples query

### DIFF
--- a/tutorials/parquet_cesium.qmd
+++ b/tutorials/parquet_cesium.qmd
@@ -348,10 +348,9 @@ async function get_samples_at_geo_cord_location_via_sample_event(pid) {
         SELECT DISTINCT
             s.pid as sample_pid,
             s.label as sample_label,
-            s.description as sample_description,
-            s.thumbnail_url,
-            s.alternate_identifiers,
+            s.name as sample_name,
             event.label as event_label,
+            event.pid as event_pid,
             site.label as site_label,
             site.pid as site_pid,
             'direct_event_location' as location_path
@@ -373,10 +372,9 @@ async function get_samples_at_geo_cord_location_via_sample_event(pid) {
         SELECT DISTINCT
             s.pid as sample_pid,
             s.label as sample_label,
-            s.description as sample_description,
-            s.thumbnail_url,
-            s.alternate_identifiers,
+            s.name as sample_name,
             event.label as event_label,
+            event.pid as event_pid,
             site.label as site_label,
             site.pid as site_pid,
             'via_site_location' as location_path
@@ -393,7 +391,7 @@ async function get_samples_at_geo_cord_location_via_sample_event(pid) {
           AND g.otype = 'GeospatialCoordLocation'
           AND g.pid = ?
 
-        ORDER BY thumbnail_url IS NOT NULL DESC, sample_label
+        ORDER BY sample_label
     `;
     const result = await loadData(q, [pid, pid], "loading_combined", "samples_combined");
     return result ?? [];
@@ -697,15 +695,14 @@ ${JSON.stringify(samples_2, null, 2)}
 
 <div id="loading_combined" hidden>Loading combined samples…</div>
 
-This query implements Eric Kansa's `get_samples_at_geo_cord_location_via_sample_event` function, which combines both Path 1 and Path 2 using UNION and returns richer sample metadata including:
+This query implements Eric Kansa's `get_samples_at_geo_cord_location_via_sample_event` function, which combines both Path 1 and Path 2 using UNION and returns sample metadata including:
 
-- Sample metadata: `sample_pid`, `sample_label`, `sample_description`
-- Visual assets: `thumbnail_url`, `alternate_identifiers`
-- Event context: `event_label`
-- Site information: `site_label`, `site_pid` (when available)
+- Sample metadata: `sample_pid`, `sample_label`, `sample_name`
+- Event context: `event_label`, `event_pid`
+- Site information: `site_label`, `site_pid` (when available via Path 2)
 - Path indicator: `location_path` (direct_event_location or via_site_location)
 
-Results are ordered with samples that have thumbnails first, making it easier to find visually rich records.
+Results are ordered alphabetically by sample label.
 
 ```{ojs}
 //| echo: false


### PR DESCRIPTION
## Bugfix for Cesium Click Query

Fixes bug introduced in PR #27 where the combined samples query was failing silently.

### Problem
The `get_samples_at_geo_cord_location_via_sample_event()` function was requesting columns that don't exist on MaterialSampleRecord nodes:
- `s.description`
- `s.thumbnail_url` (exists on event/site, causing ambiguity error)
- `s.alternate_identifiers`

This caused a DuckDB binder error: **"Ambiguous reference to column name 'thumbnail_url'"**

Result: Query returned empty array `[]` while Path 1 and Path 2 queries worked correctly.

### Solution
- Removed non-existent columns
- Use only columns that exist on MaterialSampleRecord: `pid`, `label`, `name`
- Added `event.pid` to match Path 1/2 structure
- Simplified ORDER BY (removed thumbnail_url sorting)
- Updated documentation

### Testing
- Error discovered via browser console inspection
- Verified Path 1/2 queries work with correct schema
- Query now returns sample data matching individual path queries

This is a critical fix - without it, the combined query feature doesn't work at all.