### PR TITLE
Fix button rendering with Observable html template

### DIFF
--- a/tutorials/parquet_cesium.qmd
+++ b/tutorials/parquet_cesium.qmd
@@ -48,11 +48,25 @@ viewof searchGeoPid = Inputs.text({
 ```
 
 ```{ojs}
-//| echo: fenced
-viewof classifyDots = Inputs.button("Color-code by type (sample/site/both)", {
-  value: null,
-  reduce: () => Date.now()
-})
+//| echo: false
+// Simple trigger variable that increments on button click
+viewof classifyTrigger = {
+  let count = 0;
+  const button = html`<button
+    style="padding: 8px 16px; margin: 10px 0; background: #2E86AB; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px;">
+    🎨 Color-code by type (sample/site/both)
+  </button>`;
+  button.onclick = () => {
+    count++;
+    button.value = count;
+    button.dispatchEvent(new CustomEvent("input"));
+  };
+  button.value = count;
+  return button;
+}
+
+// Alias for handler compatibility
+classifyDots = classifyTrigger > 0 ? classifyTrigger : null
 ```
 
 ::: {.callout-tip collapse="true"}


### PR DESCRIPTION
## Problem
Color-code button has rendering issues on production site:
- Button renders as black box (no visible text)
- Code block shows despite `echo: false` and `echo: fenced` directives
- Observable `Inputs.button()` widget doesn't render properly in Quarto

## Solution
Replace `Inputs.button()` with Observable `html` template literal:
- Creates button using `html` template with inline styling
- Implements `viewof` + `CustomEvent` pattern for Observable reactivity
- Maintains compatibility with existing classification handler

## Testing
✅ Tested locally with Playwright MCP:
- Button renders with proper blue styling
- Click event triggers classification handler
- Console shows "Classifying dots by type..."
- No black box or unwanted code visibility

## Changes
- **tutorials/parquet_cesium.qmd** (lines 50-70): Button implementation
  - Replaced `Inputs.button()` with `html` template
  - Added `viewof classifyTrigger` with custom onclick
  - Aliased as `classifyDots` for handler compatibility

## Deployment
Ready to merge and deploy to https://isamples.org/tutorials/parquet_cesium.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)