### PR TITLE
Add narrow vs wide parquet performance benchmark tutorial

### DIFF
--- a/tutorials/narrow_vs_wide_performance.qmd
+++ b/tutorials/narrow_vs_wide_performance.qmd
@@ -227,7 +227,12 @@ validityCheck = {
 
 ```{ojs}
 //| echo: false
-validityCheck ? html`
+validityCheck ? (validityCheck.error ? html`
+<div style="background: #f8d7da; padding: 15px; border-radius: 5px; margin: 10px 0;">
+<h4 style="margin-top: 0;">Data Validity Results</h4>
+<p style="margin: 0;"><strong>Validity check failed:</strong> ${validityCheck.error}</p>
+</div>
+` : html`
 <div style="background: ${validityCheck.sampleMatch ? '#d4edda' : '#f8d7da'}; padding: 15px; border-radius: 5px; margin: 10px 0;">
 <h4 style="margin-top: 0;">Data Validity Results</h4>
 <table style="width: 100%; border-collapse: collapse;">
@@ -240,7 +245,7 @@ validityCheck ? html`
 </table>
 <p><em>The wide schema has ~79% fewer rows because edge rows are eliminated and stored as columns.</em></p>
 </div>
-` : html`<p><em>Click "Run All Benchmarks" to check data validity</em></p>`
+`) : html`<p><em>Click "Run All Benchmarks" to check data validity</em></p>`
 ```
 
 ## Benchmark 1: Entity Count Query
@@ -283,6 +288,7 @@ benchmark1 = {
         // Calculate medians (excluding cold run for warm median)
         const median = arr => {
             const sorted = [...arr].sort((a, b) => a - b);
+            if (sorted.length === 2) return (sorted[0] + sorted[1]) / 2;
             return sorted[Math.floor(sorted.length / 2)];
         };
         const warmMedian = arr => {
@@ -318,7 +324,12 @@ benchmark1 = {
 
 ```{ojs}
 //| echo: false
-benchmark1 ? html`
+benchmark1 ? (benchmark1.error ? html`
+<div style="background: #f8d7da; padding: 15px; border-radius: 5px; margin: 10px 0;">
+<h4 style="margin-top: 0;">Benchmark 1 Error</h4>
+<p style="margin: 0;"><strong>Benchmark 1 failed:</strong> ${benchmark1.error}</p>
+</div>
+` : html`
 <div style="background: #e7f3ff; padding: 15px; border-radius: 5px; margin: 10px 0;">
 <h4 style="margin-top: 0;">${benchmark1.name}</h4>
 <table style="width: 100%; border-collapse: collapse; text-align: right;">
@@ -343,7 +354,7 @@ benchmark1 ? html`
 </table>
 <p style="margin-bottom: 0;"><strong>Speedup: ${benchmark1.speedup.toFixed(2)}x</strong> (wide is ${benchmark1.speedup > 1 ? 'faster' : 'slower'})</p>
 </div>
-` : html`<p><em>Waiting for benchmark...</em></p>`
+`) : html`<p><em>Waiting for benchmark...</em></p>`
 ```
 
 ## Benchmark 2: Sample Count by Site
@@ -437,6 +448,7 @@ benchmark2 = {
 
         const median = arr => {
             const sorted = [...arr].sort((a, b) => a - b);
+            if (sorted.length === 2) return (sorted[0] + sorted[1]) / 2;
             return sorted[Math.floor(sorted.length / 2)];
         };
         const warmMedian = arr => {
@@ -472,7 +484,12 @@ benchmark2 = {
 
 ```{ojs}
 //| echo: false
-benchmark2 ? html`
+benchmark2 ? (benchmark2.error ? html`
+<div style="background: #f8d7da; padding: 15px; border-radius: 5px; margin: 10px 0;">
+<h4 style="margin-top: 0;">Benchmark 2 Error</h4>
+<p style="margin: 0;"><strong>Benchmark 2 failed:</strong> ${benchmark2.error}</p>
+</div>
+` : html`
 <div style="background: #e7f3ff; padding: 15px; border-radius: 5px; margin: 10px 0;">
 <h4 style="margin-top: 0;">${benchmark2.name}</h4>
 <table style="width: 100%; border-collapse: collapse; text-align: right;">
@@ -497,7 +514,7 @@ benchmark2 ? html`
 </table>
 <p style="margin-bottom: 0;"><strong>Speedup: ${benchmark2.speedup.toFixed(2)}x</strong> (wide is ${benchmark2.speedup > 1 ? 'faster' : 'slower'})</p>
 </div>
-` : html`<p><em>Waiting for benchmark...</em></p>`
+`) : html`<p><em>Waiting for benchmark...</em></p>`
 ```
 
 ## Benchmark 3: Material Type Distribution
@@ -566,6 +583,7 @@ benchmark3 = {
 
         const median = arr => {
             const sorted = [...arr].sort((a, b) => a - b);
+            if (sorted.length === 2) return (sorted[0] + sorted[1]) / 2;
             return sorted[Math.floor(sorted.length / 2)];
         };
         const warmMedian = arr => {
@@ -601,7 +619,12 @@ benchmark3 = {
 
 ```{ojs}
 //| echo: false
-benchmark3 ? html`
+benchmark3 ? (benchmark3.error ? html`
+<div style="background: #f8d7da; padding: 15px; border-radius: 5px; margin: 10px 0;">
+<h4 style="margin-top: 0;">Benchmark 3 Error</h4>
+<p style="margin: 0;"><strong>Benchmark 3 failed:</strong> ${benchmark3.error}</p>
+</div>
+` : html`
 <div style="background: #e7f3ff; padding: 15px; border-radius: 5px; margin: 10px 0;">
 <h4 style="margin-top: 0;">${benchmark3.name}</h4>
 <table style="width: 100%; border-collapse: collapse; text-align: right;">
@@ -626,7 +649,7 @@ benchmark3 ? html`
 </table>
 <p style="margin-bottom: 0;"><strong>Speedup: ${benchmark3.speedup.toFixed(2)}x</strong> (wide is ${benchmark3.speedup > 1 ? 'faster' : 'slower'})</p>
 </div>
-` : html`<p><em>Waiting for benchmark...</em></p>`
+`) : html`<p><em>Waiting for benchmark...</em></p>`
 ```
 
 ## Results Summary
@@ -637,7 +660,10 @@ allResults = {
     if (!benchmark1 || !benchmark2 || !benchmark3) return null;
 
     const results = [benchmark1, benchmark2, benchmark3];
-    const avgSpeedup = results.reduce((sum, r) => sum + r.speedup, 0) / results.length;
+    const successful = results.filter(r => r && !r.error);
+    const avgSpeedup = successful.length
+        ? successful.reduce((sum, r) => sum + r.speedup, 0) / successful.length
+        : null;
 
     return {
         benchmarks: results,
@@ -659,19 +685,22 @@ allResults ? html`
 </tr>
 </thead>
 <tbody>
-${allResults.benchmarks.map(b => html`
+${allResults.benchmarks.map(b => {
+    const hasError = !b || b.error;
+    return html`
 <tr style="border-bottom: 1px solid #155724;">
-<td style="padding: 8px;">${b.name}</td>
-<td style="padding: 8px; text-align: center;">${b.narrowMedian.toFixed(0)}</td>
-<td style="padding: 8px; text-align: center;">${b.wideMedian.toFixed(0)}</td>
-<td style="padding: 8px; text-align: center; font-weight: bold;">${b.speedup.toFixed(2)}x</td>
+<td style="padding: 8px;">${b?.name || 'Benchmark'}</td>
+<td style="padding: 8px; text-align: center;">${hasError ? 'N/A' : b.narrowMedian.toFixed(0)}</td>
+<td style="padding: 8px; text-align: center;">${hasError ? 'N/A' : b.wideMedian.toFixed(0)}</td>
+<td style="padding: 8px; text-align: center; font-weight: bold;">${hasError ? `Error: ${b?.error || 'Unavailable'}` : `${b.speedup.toFixed(2)}x`}</td>
 </tr>
-`)}
+`;
+})}
 <tr style="background: #c3e6cb; font-weight: bold;">
 <td style="padding: 8px;">Average</td>
 <td style="padding: 8px; text-align: center;">-</td>
 <td style="padding: 8px; text-align: center;">-</td>
-<td style="padding: 8px; text-align: center;">${allResults.avgSpeedup.toFixed(2)}x</td>
+<td style="padding: 8px; text-align: center;">${allResults.avgSpeedup != null ? `${allResults.avgSpeedup.toFixed(2)}x` : 'N/A'}</td>
 </tr>
 </tbody>
 </table>
@@ -680,7 +709,7 @@ ${allResults.benchmarks.map(b => html`
 <ul>
 <li><strong>File size reduction:</strong> Wide format is 60% smaller (275 MB vs 691 MB)</li>
 <li><strong>Row count reduction:</strong> Wide format has 79% fewer rows (~2.5M vs ~11.6M)</li>
-<li><strong>Query speedup:</strong> Average ${allResults.avgSpeedup.toFixed(1)}x faster with wide format</li>
+<li><strong>Query speedup:</strong> ${allResults.avgSpeedup != null ? `Average ${allResults.avgSpeedup.toFixed(1)}x faster with wide format` : 'Unavailable due to benchmark errors'}</li>
 </ul>
 
 <h4>Recommendation</h4>
@@ -706,7 +735,7 @@ ${allResults.benchmarks.map(b => html`
 | Consideration | How We Address It |
 |---------------|-------------------|
 | **Browser caching** | First run is "cold" (metadata not cached), subsequent runs are "warm" |
-| **Network variability** | We run 3 iterations and report the median |
+| **Network variability** | We run 3 iterations and report the warm-run median (exclude cold run) |
 | **JIT compilation** | First run includes JIT overhead; warm runs are more representative |
 | **Memory limits** | 691 MB narrow file may stress browser memory; wide format is safer |
 


### PR DESCRIPTION
## Summary
- Adds interactive browser-based benchmarks comparing narrow (691MB, 11.6M rows) vs wide (275MB, 2.5M rows) parquet schemas
- Three benchmarks: entity counts, site aggregation, material distribution
- Multiple runs with median timing for reliability
- Environment info display and data validity checks
- Technical notes on caching, cold starts, and memory limits

## Context
This addresses Eric's question about whether the 2-3x speedup seen locally also holds "over the wire" with HTTP range requests via DuckDB-WASM.

## Test plan
- [ ] Run quarto preview on the new tutorial
- [ ] Verify "Run All Benchmarks" button executes successfully
- [ ] Check all three benchmarks show timing comparisons
- [ ] Verify results summary table populates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)