### PR TITLE
Add Narrow vs Wide Performance tutorial to sidebar navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -55,6 +55,8 @@ website:
           href: tutorials/parquet_cesium.qmd
         - text: "Cesium View split sources"
           href: tutorials/parquet_cesium_split.qmd
+        - text: "Narrow vs Wide Performance"
+          href: tutorials/narrow_vs_wide_performance.qmd
 
   repo-url: https://github.com/isamplesorg/isamplesorg.github.io
   repo-actions: [edit, issue]


### PR DESCRIPTION
## Summary

The tutorial was merged in PR #40 but wasn't added to the sidebar navigation. This adds it to the "Getting Started" section.

## Changes

- Added "Narrow vs Wide Performance" link to `_quarto.yml` sidebar under "Getting Started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)