### PR TITLE
Fix vocab generation: use vocab CLI instead of vocab2md.py

### DIFF
--- a/scripts/generate_vocab_docs.sh
+++ b/scripts/generate_vocab_docs.sh
@@ -2,6 +2,7 @@
 #
 # Regenerates the vocabulary markdown files from the GH sources
 #
+# Uses 'vocab' CLI from vocab_tools (installed via pipx in workflow)
 #
 
 # get the core sample type vocabularies
@@ -15,7 +16,7 @@ mkdir -p "${DEST_FOLDER}"
 for src in ${SOURCES[@]}; do
     fname="${src%%.*}.qmd"
     echo "Generating ${fname}..."
-    python "${SCRIPT_FOLDER}/vocab2md.py" "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
+    vocab markdown "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
 done
 
 #
@@ -33,7 +34,7 @@ mkdir -p "${DEST_FOLDER}"
 for src in ${SOURCES[@]}; do
     fname="${src%%.*}.md"
     echo "Generating ${fname}..."
-    python "${SCRIPT_FOLDER}/vocab2md.py" "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
+    vocab markdown "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
 done
 
 SOURCE_BASE="https://raw.githubusercontent.com/isamplesorg/metadata_profile_archaeology/main/vocabulary/"
@@ -43,7 +44,7 @@ mkdir -p "${DEST_FOLDER}"
 for src in ${SOURCES[@]}; do
     fname="${src%%.*}.md"
     echo "Generating ${fname}..."
-    python "${SCRIPT_FOLDER}/vocab2md.py" "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
+    vocab markdown "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
 done
 
 SOURCE_BASE="https://raw.githubusercontent.com/isamplesorg/metadata_profile_biology/main/vocabulary/"
@@ -53,7 +54,7 @@ mkdir -p "${DEST_FOLDER}"
 for src in ${SOURCES[@]}; do
     fname="${src%%.*}.md"
     echo "Generating ${fname}..."
-    python "${SCRIPT_FOLDER}/vocab2md.py" "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
+    vocab markdown "${SOURCE_BASE}${src}" > "${DEST_FOLDER}${fname}"
 done
 
 echo "Done."


### PR DESCRIPTION
## Problem

PR #46 switched from `vocab markdown` CLI to `python vocab2md.py`, but `vocab2md.py` requires `rdflib` which isn't installed in the workflow environment.

This caused all vocabulary generation to fail with:
```
ModuleNotFoundError: No module named 'rdflib'
```

Result: vocabulary pages render with empty content.

## Fix

Revert to using `vocab markdown` CLI from `vocab_tools`, which is already installed via pipx in the workflow:

```yaml
- name: "install vocab_tools"
  run: pipx install git+https://github.com/isamplesorg/vocab_tools.git@main
```

## Changes

- `scripts/generate_vocab_docs.sh`: Replace `python vocab2md.py` with `vocab markdown`
- Added comment explaining the vocab_tools dependency

## Test Plan

- [ ] Merge and trigger workflow
- [ ] Verify vocabulary pages at https://isamples.org/models/ have content

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)