### PR TITLE
Progressive globe: source links, filtering, and stats clarity

### DIFF
--- a/tutorials/progressive_globe.qmd
+++ b/tutorials/progressive_globe.qmd
@@ -171,7 +171,8 @@ function getActiveSources() {
 
 function sourceFilterSQL(col) {
     const active = getActiveSources();
-    if (active.length === 0 || active.length === 4) return '';  // all or none = no filter
+    if (active.length === 0) return ' AND 1=0';  // nothing checked = show nothing
+    if (active.length === 4) return '';           // all checked = no filter
     const list = active.map(s => `'${s}'`).join(',');
     return ` AND ${col} IN (${list})`;
 }
@@ -554,8 +555,9 @@ zoomWatcher = {
     let cachedData = null;    // array of rows
 
     // --- H3 cluster loading (existing logic) ---
+    let loadResGen = 0;  // generation counter to discard stale results
     const loadRes = async (res, url) => {
-        if (loading) return;
+        const gen = ++loadResGen;  // claim a generation
         loading = true;
         updatePhaseMsg(`Loading H3 res${res}...`, 'loading');
 
@@ -568,6 +570,7 @@ zoomWatcher = {
                 WHERE 1=1${sourceFilterSQL('dominant_source')}
             `);
 
+            if (gen !== loadResGen) return;  // stale — a newer call superseded this one
             viewer.h3Points.removeAll();
             const scalar = new Cesium.NearFarScalar(1.5e2, 1.5, 8.0e6, 0.3);
             let total = 0;
@@ -776,11 +779,11 @@ zoomWatcher = {
             li.classList.toggle('disabled', !cb.checked);
         });
         if (mode === 'cluster') {
-            loading = false;  // reset guard so loadRes can fire
+            loading = false;  // allow loadRes to run (gen counter discards stale results)
             await loadRes(currentRes, resUrls[currentRes]);
         } else {
             cachedBounds = null;  // force re-query
-            loadViewportSamples();
+            await loadViewportSamples();
         }
     });
 


### PR DESCRIPTION
## Summary

- **Source links**: Sample cards now link to original repository records via `https://n2t.net/{pid}` — works for all 4 sources (OpenContext, SESAR, GEOME, Smithsonian)
- **Source filtering**: Legend dots converted to interactive checkboxes — users can toggle sources on/off, SQL queries re-filter in real time across all zoom levels
- **Stats label clarity**: Stats panel now distinguishes "Clusters Loaded" vs "Samples Loaded" and "in View / Loaded" counts

## Details

### Source links (commit 86c3d6a)
- Added `sourceUrl(pid)` helper using universal `n2t.net` resolver
- Sample detail card shows "View at [Source Name] →" link
- Nearby samples list has clickable labels linking to source
- Removed generic "Open in Analysis Tool" placeholder link

### Faceted filtering (commit 49f8164)
- `getActiveSources()` and `sourceFilterSQL(col)` helpers inject WHERE clauses
- Filter applied to all 4 query locations: phase1 clusters, loadRes, loadViewportSamples, cluster-click nearby
- No performance penalty when all sources selected (empty SQL fragment)
- Unchecked sources visually dimmed

### Stats labels (commit 6b24976)
- Dynamic label: "Clusters Loaded" at H3 zoom, "Samples Loaded" at point zoom
- "in View / Loaded" ratio shown when applicable

## Test plan

- [ ] Verify source links open correct records for each of the 4 sources
- [ ] Toggle source checkboxes and confirm map updates at each zoom level
- [ ] Check stats labels change appropriately between cluster and point modes
- [ ] Confirm no JS errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)