### PR TITLE
Fix isamples_explorer: mutable variable for facet summaries

### DIFF
--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -337,15 +337,20 @@ async function runQuery(sql) {
 
 ```{ojs}
 //| code-fold: true
+mutable facetSummariesError = null
+```
+
+```{ojs}
+//| code-fold: true
 // Tier 1: Load pre-computed facet summaries (2KB, instant)
 facetSummaries = {
-  facetSummariesError = null;
+  mutable facetSummariesError = null;
   try {
     const rows = await runQuery(`SELECT * FROM read_parquet('${facet_summaries_url}')`);
     return rows;
   } catch (e) {
     console.error("Facet summaries load error:", e);
-    facetSummariesError = e;
+    mutable facetSummariesError = e;
     return [];
   }
 }


### PR DESCRIPTION
## Summary

- **Bug**: Explorer page completely broken — all filters, queries, and rendering failed with `RuntimeError: facetSummaries is not defined`
- **Root cause**: `facetSummariesError` was assigned without being declared as `mutable` in OJS, which killed the `facetSummaries` cell and cascaded to every downstream cell
- **Fix**: Added `mutable facetSummariesError = null` declaration and used `mutable` keyword when assigning

## Test plan

- [ ] Load https://isamples.org/tutorials/isamples_explorer.html
- [ ] Verify search box, source filters, and globe all render
- [ ] Check browser console for no `facetSummaries is not defined` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)