### PR TITLE
Fix broken tutorial pages: explorer and zenodo analysis

### DIFF
--- a/tutorials/zenodo_isamples_analysis.qmd
+++ b/tutorials/zenodo_isamples_analysis.qmd
@@ -169,9 +169,16 @@ db = {
   
   if (working_parquet_url) {
     try {
-      // Try to create view of the remote parquet file
-      await conn.query(`CREATE VIEW isamples_data AS SELECT * FROM read_parquet('${working_parquet_url}')`);
-      
+      // Create view with aliased column names to match downstream queries.
+      // The Jan 2026 wide parquet uses different names than the original schema.
+      await conn.query(`CREATE VIEW isamples_data AS SELECT *,
+        latitude AS sample_location_latitude,
+        longitude AS sample_location_longitude,
+        n AS source_collection,
+        pid AS sample_identifier,
+        CAST(NULL AS VARCHAR) AS has_material_category
+        FROM read_parquet('${working_parquet_url}')`);
+
       // Test the connection with a simple query to catch rate limiting
       await conn.query(`SELECT count(*) FROM isamples_data LIMIT 1`);
       console.log("✅ Successfully connected to remote Parquet file");


### PR DESCRIPTION
## Summary

Fixes two broken tutorial pages on isamples.org:

- **isamples_explorer** (PR #54, already merged): `facetSummariesError` assigned without `mutable` keyword in OJS, killing all downstream cells
- **zenodo_isamples_analysis** (this PR): SQL queries used old column names (`sample_location_latitude`, `source_collection`) but the Jan 2026 wide parquet has different names (`latitude`, `longitude`, `n`). Added column aliases in the view creation.

## What works now
- Dataset overview: 20.7M records, 11.96M with coordinates
- Source collection table and bar chart
- Geographic statistics and regional distribution
- Interactive sampling and world map
- Viewport map with DuckDB-WASM

## Known limitation
- Material Category Analysis section shows empty — the wide format stores categories as integer arrays (`p__has_material_category`) not strings. Full fix would require joining back to concept nodes.

## Test plan
- [x] Playwright smoke test: zero Binder Errors (was 57+ before fix)
- [x] Source collection table renders with correct counts
- [x] Geographic charts render
- [ ] Manual verification on isamples.org after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)