### PR TITLE
Redesign homepage, add navbar, restructure navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,8 +3,24 @@ project:
   output-dir: docs
 
 website:
-  title: "iSamples"  
+  title: "iSamples"
   favicon: assets/isamplesfavicon.ico
+  navbar:
+    logo: assets/isampleslogopetal.png
+    left:
+      - href: index.qmd
+        text: Home
+      - href: tutorials/progressive_globe.qmd
+        text: Interactive Explorer
+      - href: tutorials/index.qmd
+        text: Tutorials
+      - href: about.qmd
+        text: About
+    right:
+      - icon: github
+        href: https://github.com/isamplesorg
+      - icon: slack
+        href: https://isamples.slack.com/
   sidebar:
     style: "docked"
     search: true

--- a/index.qmd
+++ b/index.qmd
@@ -3,6 +3,8 @@ title: "Internet of Samples: iSamples"
 subtitle: "Toward an Interdisciplinary Cyberinfrastructure for Material Samples"
 number-sections: false
 toc: false
+sidebar: false
+page-layout: full
 ---
 
 ::: {.column-page}


### PR DESCRIPTION
## Summary

- **Homepage redesign (#58)**: Full-width landing page with globe hero, impact stats (6.7M samples, 4 repos, 90+ countries), sample showcase gallery, three collapsible Q&A sections, Moorea video
- **Navigation restructure (#60)**: Top navbar on all pages (Home, Interactive Explorer, Tutorials, About). Sidebar hidden on homepage, available on interior pages. Visitor-first ordering.
- **Outputs split (#63)**: "Outputs" → "Published Research" (papers, talks) + "Resources" (Zenodo, GitHub)

## Changes

- `index.qmd` — new homepage with `sidebar: false`, `page-layout: full`
- `_quarto.yml` — added navbar, reorganized sidebar contents

## Screenshots

Homepage: globe hero → stats → thumbnails → accordions → video, no sidebar
Interior pages: top navbar + left sidebar for deep navigation

## Test plan

- [x] Full site render (32/32 pages, no errors)
- [x] Playwright screenshot verification
- [ ] Manual review on isamples.org after deploy

Closes #58, #60, #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)