### PR TITLE
Use data.isamples.org for all parquet file URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ All tutorials query parquet files hosted on Cloudflare R2:
 
 ```javascript
 // Wide format (recommended) - 280 MB, 20M rows
-const WIDE_URL = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet";
+const WIDE_URL = "https://data.isamples.org/isamples_202601_wide.parquet";
 
 // Narrow format (advanced) - 850 MB, 106M rows
-const NARROW_URL = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202512_narrow.parquet";
+const NARROW_URL = "https://data.isamples.org/isamples_202512_narrow.parquet";
 ```
 
 ## Related Repositories

--- a/scripts/profile_queries.py
+++ b/scripts/profile_queries.py
@@ -17,7 +17,7 @@ from typing import Optional
 import duckdb
 
 # Data sources
-REMOTE_URL = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet"
+REMOTE_URL = "https://data.isamples.org/isamples_202601_wide.parquet"
 LOCAL_PATH = "/tmp/isamples_202601_wide.parquet"
 
 # Sample geocode PIDs for point selection tests (will be populated from data)

--- a/tools/globe_capture.html
+++ b/tools/globe_capture.html
@@ -57,7 +57,7 @@ const globalRect = Cesium.Rectangle.fromDegrees(-180, -60, 180, 80);
 viewer.camera.setView({ destination: globalRect });
 
 // Load H3 cluster data from R2
-const R2 = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev";
+const R2 = "https://data.isamples.org";
 
 async function loadData() {
   const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();

--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -26,10 +26,10 @@ duckdbModule = import("https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.28.0/+
 ```{ojs}
 //| code-fold: true
 // Data source configuration
-parquet_url = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet"
+parquet_url = "https://data.isamples.org/isamples_202601_wide.parquet"
 
 // Pre-computed facet summaries (2KB - loads instantly)
-facet_summaries_url = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_facet_summaries.parquet"
+facet_summaries_url = "https://data.isamples.org/isamples_202601_facet_summaries.parquet"
 
 // Source color scheme (consistent with iSamples conventions)
 SOURCE_COLORS = ({

--- a/tutorials/narrow_vs_wide_performance.qmd
+++ b/tutorials/narrow_vs_wide_performance.qmd
@@ -64,10 +64,10 @@ import { DuckDBClient } from "https://cdn.jsdelivr.net/npm/@observablehq/duckdb@
 //| echo: false
 // Define parquet URLs - iSamples full dataset on Cloudflare R2 (all sources)
 // Updated 2026-01-14: Using Zenodo narrow/wide files on Cloudflare R2
-narrowUrl = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202512_narrow.parquet"
-wideUrl = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet"
-wideH3Url = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide_h3.parquet"
-summariesUrl = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_facet_summaries.parquet"
+narrowUrl = "https://data.isamples.org/isamples_202512_narrow.parquet"
+wideUrl = "https://data.isamples.org/isamples_202601_wide.parquet"
+wideH3Url = "https://data.isamples.org/isamples_202601_wide_h3.parquet"
+summariesUrl = "https://data.isamples.org/isamples_202601_facet_summaries.parquet"
 ```
 
 ### Environment Info

--- a/tutorials/parquet_cesium_isamples_wide.qmd
+++ b/tutorials/parquet_cesium_isamples_wide.qmd
@@ -45,7 +45,7 @@ Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOi
 //| echo: false
 viewof parquet_path = Inputs.text({
   label:"Source (iSamples Wide Format + H3)",
-  value:"https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide_h3.parquet",
+  value:"https://data.isamples.org/isamples_202601_wide_h3.parquet",
   placeholder: "URL or file:///path/to/file.parquet",
   width:"100%",
   submit:true
@@ -123,7 +123,7 @@ Download the file locally, then serve it:
 
 ```bash
 # Download the wide parquet file (~242MB)
-curl -O https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet
+curl -O https://data.isamples.org/isamples_202601_wide.parquet
 
 # Serve it locally
 python3 -m http.server 8000

--- a/tutorials/progressive_globe.qmd
+++ b/tutorials/progressive_globe.qmd
@@ -197,7 +197,7 @@ Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOi
 //| output: false
 
 // === Constants ===
-R2_BASE = "https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev"
+R2_BASE = "https://data.isamples.org"
 h3_res4_url = `${R2_BASE}/isamples_202601_h3_summary_res4.parquet`
 h3_res6_url = `${R2_BASE}/isamples_202601_h3_summary_res6.parquet`
 h3_res8_url = `${R2_BASE}/isamples_202601_h3_summary_res8.parquet`

--- a/tutorials/zenodo_isamples_analysis.qmd
+++ b/tutorials/zenodo_isamples_analysis.qmd
@@ -28,14 +28,14 @@ This tutorial demonstrates how to efficiently analyze large geospatial datasets 
 ## Dataset Information
 
 **Primary dataset** (Jan 2026, H3-indexed):
-- **URL**: `https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide_h3.parquet`
+- **URL**: `https://data.isamples.org/isamples_202601_wide_h3.parquet`
 - **Size**: ~292 MB wide format with H3 indices, 6.7M MaterialSampleRecords (20M total rows)
 - **H3 columns**: Pre-computed `h3_res4`, `h3_res6`, `h3_res8` (BIGINT) for spatial grouping
 - **Sources**: SESAR (4.6M), OpenContext (1M), GEOME (605K), Smithsonian (322K)
 - **Hosting**: Cloudflare R2 with HTTP range request support
 
 **Facet summaries** (2KB, instant):
-- **URL**: `https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_facet_summaries.parquet`
+- **URL**: `https://data.isamples.org/isamples_202601_facet_summaries.parquet`
 - **Schema**: `facet_type`, `facet_value`, `scheme`, `count`
 
 **Note**: *Data was originally archived on Zenodo and is now served from Cloudflare R2 for better performance and reliability.*
@@ -88,10 +88,10 @@ topojson = require("topojson-client@3")
 // Dataset URLs - try multiple options for CORS compatibility
 // Primary: Cloudflare R2 (Jan 2026 wide format with H3 indices)
 parquet_urls = [
-  'https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide_h3.parquet',
+  'https://data.isamples.org/isamples_202601_wide_h3.parquet',
 
   // Fallback: original wide format without H3
-  'https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_wide.parquet',
+  'https://data.isamples.org/isamples_202601_wide.parquet',
 
   // Fallback: older versions
   'https://labs.dataunbound.com/docs/2025/07/isamples_export_2025_04_21_16_23_46_geo.parquet',
@@ -99,7 +99,7 @@ parquet_urls = [
 ]
 
 // Pre-computed facet summaries (2KB - loads instantly)
-facet_summaries_url = 'https://pub-a18234d962364c22a50c787b7ca09fa5.r2.dev/isamples_202601_facet_summaries.parquet'
+facet_summaries_url = 'https://data.isamples.org/isamples_202601_facet_summaries.parquet'
 
 // Test CORS and find working URL - with rate limiting protection
 working_parquet_url = {


### PR DESCRIPTION
## Summary
- Replaces all `pub-a18234d962364c22a50c787b7ca09fa5.r2.dev` references with `data.isamples.org`
- 18 URL replacements across 8 files (tutorials, README, tools, scripts)
- Cloudflare zone activated 2026-04-03, Worker route verified with range requests + CORS

## Test plan
- [ ] `curl -I https://data.isamples.org/isamples_202601_wide.parquet` returns 206
- [ ] `quarto preview` and verify Interactive Explorer loads data
- [ ] Check progressive globe tutorial still renders

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)