### PR TITLE
Improve search: multi-term AND + relevance ranking (FTS spike)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ models/generated/extensions/*.md
 
 # Large data files
 *.parquet
+*.duckdb
 
 # Node / Playwright
 node_modules/

--- a/tools/build_fts_index.py
+++ b/tools/build_fts_index.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Build a DuckDB full-text search index for the iSamples Explorer.
+
+Creates a .duckdb file containing the FTS index (BM25-scored) that can
+be ATTACHed in DuckDB-WASM for ranked text search over 6.7M samples.
+
+Usage:
+    python tools/build_fts_index.py
+
+Output:
+    tools/isamples_fts_index.duckdb  (upload to data.isamples.org)
+
+Requirements:
+    pip install duckdb
+"""
+
+import duckdb
+import os
+import sys
+from pathlib import Path
+
+PARQUET_URL = "https://data.isamples.org/isamples_202601_wide.parquet"
+OUTPUT_DB = Path(__file__).parent / "isamples_fts_index.duckdb"
+
+# Local fallback for faster builds
+LOCAL_PARQUET = Path.home() / "Data/iSample/pqg_refining/zenodo_wide_2026-01-09.parquet"
+
+
+def build_fts_index():
+    # Use local file if available, otherwise remote
+    source = str(LOCAL_PARQUET) if LOCAL_PARQUET.exists() else PARQUET_URL
+    print(f"Source: {source}")
+
+    # Remove existing index file
+    if OUTPUT_DB.exists():
+        OUTPUT_DB.unlink()
+
+    con = duckdb.connect(str(OUTPUT_DB))
+
+    print("Creating samples table from parquet...")
+    con.execute(f"""
+        CREATE TABLE samples AS
+        SELECT
+            pid,
+            label,
+            COALESCE(description, '') AS description,
+            COALESCE(CAST(place_name AS VARCHAR), '') AS place_name
+        FROM read_parquet('{source}')
+        WHERE otype = 'MaterialSampleRecord'
+    """)
+
+    row_count = con.execute("SELECT COUNT(*) FROM samples").fetchone()[0]
+    print(f"Loaded {row_count:,} rows")
+
+    print("Installing and loading FTS extension...")
+    con.execute("INSTALL fts")
+    con.execute("LOAD fts")
+
+    print("Building FTS index (this may take a few minutes)...")
+    con.execute("""
+        PRAGMA create_fts_index(
+            'samples', 'pid',
+            'label', 'description', 'place_name',
+            stemmer = 'porter',
+            stopwords = 'english',
+            overwrite = 1
+        )
+    """)
+
+    # Verify the index works
+    test_result = con.execute("""
+        SELECT pid, fts_main_samples.match_bm25(pid, 'pottery') AS score
+        FROM samples
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+        LIMIT 5
+    """).fetchall()
+    print(f"Test query 'pottery': {len(test_result)} results")
+    for pid, score in test_result:
+        print(f"  {pid[:60]}  score={score:.4f}")
+
+    # Keep samples table — FTS macros reference it internally.
+    # The table has only pid + text columns (not the full schema),
+    # so it's much smaller than the full parquet.
+
+    con.close()
+
+    size_mb = OUTPUT_DB.stat().st_size / (1024 * 1024)
+    print(f"\nIndex file: {OUTPUT_DB}")
+    print(f"Size: {size_mb:.1f} MB")
+    print(f"\nUpload to data.isamples.org and ATTACH in DuckDB-WASM:")
+    print(f"  ATTACH 'https://data.isamples.org/isamples_fts_index.duckdb' AS fts_db;")
+
+
+if __name__ == "__main__":
+    build_fts_index()

--- a/tools/build_fts_index.py
+++ b/tools/build_fts_index.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
 """
+STATUS: spike artifact — NOT in production pipeline.
+
 Build a DuckDB full-text search index for the iSamples Explorer.
 
-Creates a .duckdb file containing the FTS index (BM25-scored) that can
-be ATTACHed in DuckDB-WASM for ranked text search over 6.7M samples.
+This script was used to evaluate whether DuckDB FTS could replace the
+ILIKE-based search in the Explorer. Findings (PR #95):
+  - Full index (label + description + place_name): 358 MB
+  - Lite index (label + place_name only):          211 MB
+  - ATTACH-over-HTTP works in DuckDB-WASM, but the download is too
+    large for an interactive page.
+The Explorer continues to use ILIKE; this script is preserved so we
+can revisit FTS once we have a smaller index strategy (e.g.
+pre-tokenized inverted index as parquet, or on-demand loading behind
+an "Enhanced Search" toggle).
 
 Usage:
     python tools/build_fts_index.py
 
 Output:
-    tools/isamples_fts_index.duckdb  (upload to data.isamples.org)
+    tools/isamples_fts_index.duckdb  (NOT currently uploaded anywhere)
 
 Requirements:
     pip install duckdb
@@ -89,8 +99,8 @@ def build_fts_index():
     size_mb = OUTPUT_DB.stat().st_size / (1024 * 1024)
     print(f"\nIndex file: {OUTPUT_DB}")
     print(f"Size: {size_mb:.1f} MB")
-    print(f"\nUpload to data.isamples.org and ATTACH in DuckDB-WASM:")
-    print(f"  ATTACH 'https://data.isamples.org/isamples_fts_index.duckdb' AS fts_db;")
+    print(f"\nNOTE: Index is too large to ship to the browser as-is.")
+    print(f"      See module docstring for the spike findings.")
 
 
 if __name__ == "__main__":

--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -173,7 +173,7 @@ Circle size = log(sample count). Color = dominant data source.
 
 <!-- Static layout: globe + side panel. Updated via DOM, not OJS reactivity. -->
 <div class="search-bar">
-<input type="text" id="sampleSearch" placeholder="Search samples (e.g., basalt, pottery, coral...)" />
+<input type="text" id="sampleSearch" placeholder="Search samples - multiple words narrow results (e.g., pottery Cyprus)" />
 <button id="searchBtn">Search</button>
 </div>
 <div id="searchResults" class="search-results"></div>
@@ -313,6 +313,37 @@ function sourceFilterSQL(col) {
     if (active.length === 0 || active.length === 4) return '';
     const list = active.map(s => `'${s}'`).join(',');
     return ` AND ${col} IN (${list})`;
+}
+
+// === Text search SQL helpers ===
+function searchTerms(value) {
+    return String(value || '').trim().split(/\s+/).filter(Boolean);
+}
+
+function escapeSqlString(value) {
+    return String(value).replace(/'/g, "''");
+}
+
+function escapeIlikePattern(value) {
+    return escapeSqlString(value).replace(/[\\%_]/g, "\\$&");
+}
+
+function textSearchWhere(terms, columns) {
+    return terms.map(raw => {
+        const term = escapeIlikePattern(raw);
+        const checks = columns.map(col => `${col} ILIKE '%${term}%' ESCAPE '\\'`);
+        return `(${checks.join(' OR ')})`;
+    }).join(' AND ');
+}
+
+function textSearchScore(terms, weightedColumns) {
+    if (!terms.length) return '0';
+    return terms.map(raw => {
+        const term = escapeIlikePattern(raw);
+        return weightedColumns.map(({ col, weight }) =>
+            `CASE WHEN ${col} ILIKE '%${term}%' ESCAPE '\\' THEN ${weight} ELSE 0 END`
+        ).join(' + ');
+    }).map(score => `(${score})`).join(' + ');
 }
 
 // === Material/Context Filters ===
@@ -1620,26 +1651,40 @@ zoomWatcher = {
         }
         searchResults.textContent = 'Searching...';
         try {
-            const escaped = term.replace(/'/g, "''");
+            const terms = searchTerms(term);
             // Compose with facet filters so search honors the same Material /
             // Sampled Feature / Specimen Type selections that the table and
             // point-mode globe use. Without this, search would surface (and
             // fly to) samples outside the active filters.
             const facetActive = hasFacetFilters();
             const facetSQL = facetActive ? facetFilterSQL() : '';
+            const aliasedSearchWhere = textSearchWhere(terms, ['l.label', 'CAST(l.place_name AS VARCHAR)']);
+            const aliasedScore = textSearchScore(terms, [
+                { col: 'l.label', weight: 3 },
+                { col: 'CAST(l.place_name AS VARCHAR)', weight: 2 },
+            ]);
+            const searchWhere = textSearchWhere(terms, ['label', 'CAST(place_name AS VARCHAR)']);
+            const score = textSearchScore(terms, [
+                { col: 'label', weight: 3 },
+                { col: 'CAST(place_name AS VARCHAR)', weight: 2 },
+            ]);
             const query = facetActive ? `
-                SELECT l.pid, l.label, l.source, l.latitude, l.longitude, l.place_name
+                SELECT l.pid, l.label, l.source, l.latitude, l.longitude, l.place_name,
+                       (${aliasedScore}) AS relevance_score
                 FROM read_parquet('${lite_url}') l
                 JOIN read_parquet('${facets_url}') f ON l.pid = f.pid
-                WHERE l.label ILIKE '%${escaped}%'
+                WHERE ${aliasedSearchWhere}
                 ${sourceFilterSQL('l.source')}
                 ${facetSQL}
+                ORDER BY relevance_score DESC, l.label
                 LIMIT 50
             ` : `
-                SELECT pid, label, source, latitude, longitude, place_name
+                SELECT pid, label, source, latitude, longitude, place_name,
+                       (${score}) AS relevance_score
                 FROM read_parquet('${lite_url}')
-                WHERE label ILIKE '%${escaped}%'
+                WHERE ${searchWhere}
                 ${sourceFilterSQL('source')}
+                ORDER BY relevance_score DESC, label
                 LIMIT 50
             `;
             const results = await db.query(query);


### PR DESCRIPTION
## Summary

Closes #84 — FTS spike complete with immediate search improvements and documented future path.

**Shipped now (zero new dependencies):**
- **Multi-term search**: "pottery Cyprus" requires BOTH words to match (was OR on the full phrase)
- **Wildcard-safe ILIKE**: search terms containing `%`, `_`, or `\` are escaped, so they match literal characters instead of acting as wildcards
- **Relevance ranking**: results sorted by score when searching — label match = 3pts, place_name = 2pts. (Description is not scored — the column lives in the wide parquet, while the Explorer's search runs against the lite parquet, which has no description.)
- When not searching, results remain random for exploration variety
- Search composes with active facet filters (Material / Sampled Feature / Specimen Type) and the source legend, so results stay inside the user's current narrowing

**FTS spike findings:**
- Built offline DuckDB FTS index with `tools/build_fts_index.py` (preserved as a non-production spike artifact, clearly marked in its module docstring)
- Full index (label + description + place_name): **358 MB** — too large for auto-download
- Lite index (label + place_name only): **211 MB** — still substantial
- BM25 scoring works well (Porter stemming, English stopwords)
- `ATTACH` over HTTP in DuckDB-WASM is supported but downloading 200–358 MB is impractical

**Recommended next steps (not in this PR):**
1. Explore pre-tokenized search parquet (inverted index as parquet, much smaller)
2. Consider on-demand FTS loading behind an "Enhanced Search" toggle
3. Evaluate DuckDB text analytics functions (stemming without full index)

## Test plan

- [ ] Search "pottery" → results ranked by relevance (label matches first)
- [ ] Search "pottery Cyprus" → only samples matching BOTH words
- [ ] Search "basalt" → geological samples with label matches at top
- [ ] Search "100%" or other wildcard chars → matches the literal characters, not all rows
- [ ] Clear search → results return to random sampling
- [ ] With Material/Source/Specimen filters active → search results stay inside those filters
- [ ] `tools/build_fts_index.py` runs successfully with local parquet (spike artifact, not part of the deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
