### PR TITLE
Fix last 3 xfail tests — all 52 now pass

### DIFF
--- a/tests/test_about_features.py
+++ b/tests/test_about_features.py
@@ -1,0 +1,73 @@
+"""
+Feature: About Page
+  As a visitor learning about iSamples
+  I want to navigate to specific sections via anchors
+  And see team photos and PI information
+  So that I understand who is behind the project
+
+  Wireframe ref: Figma frame [33:919] About
+"""
+import pytest
+from conftest import SITE_URL
+
+
+class TestAboutAnchors:
+    """Scenario: Section anchors scroll to correct content."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
+    def test_team_anchor_scrolls_to_team(self, page):
+        """Given I navigate to about.html#team, Then the Team section is visible."""
+        page.goto(f"{SITE_URL}/about.html#team", wait_until="domcontentloaded")
+        heading = page.locator("h2:has-text('Team')")
+        assert heading.count() > 0
+        assert heading.first.is_visible()
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
+    def test_photo_gallery_anchor(self, page):
+        """Given I navigate to about.html#photo-gallery, Then the Photo Gallery is visible."""
+        page.goto(f"{SITE_URL}/about.html#photo-gallery", wait_until="domcontentloaded")
+        heading = page.locator("h2:has-text('Photo Gallery')")
+        assert heading.count() > 0
+        assert heading.first.is_visible()
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
+    def test_background_anchor(self, page):
+        """Given I navigate to about.html#background-history, Then Background section is visible."""
+        page.goto(f"{SITE_URL}/about.html#background-history", wait_until="domcontentloaded")
+        heading = page.locator("h2:has-text('Background')")
+        assert heading.count() > 0
+
+
+class TestAboutPILinks:
+    """Scenario: PI names link to ORCID profiles."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — PI ORCID links")
+    def test_pi_names_have_orcid_links(self, page):
+        """Given I am on the about page, Then each PI name links to an ORCID profile."""
+        page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
+        orcid_links = page.locator("a[href*='orcid.org']")
+        assert orcid_links.count() >= 4, f"Expected 4 ORCID links, found {orcid_links.count()}"
+
+
+class TestAboutGallery:
+    """Scenario: Photo gallery displays workshop and facility images."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — gallery images")
+    def test_gallery_has_images(self, page):
+        """Given I am on the about page, Then the photo gallery has at least 6 images."""
+        page.goto(f"{SITE_URL}/about.html#photo-gallery", wait_until="domcontentloaded")
+        gallery_section = page.locator("#photo-gallery ~ div img, #photo-gallery ~ .columns img")
+        # Fallback: count all images near the gallery heading
+        if gallery_section.count() == 0:
+            gallery_section = page.locator("img[src*='gallery'], img[src*='workshop'], img[src*='tucson'], img[src*='smithsonian']")
+        assert gallery_section.count() >= 3, f"Expected gallery images, found {gallery_section.count()}"
+
+
+class TestAboutContributors:
+    """Scenario: Contributors section lists project participants."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — contributors list")
+    def test_contributors_section_expandable(self, page):
+        """Given I am on the about page, Then I can expand the Contributors section."""
+        page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
+        assert page.get_by_text("Contributors").count() > 0

--- a/tests/test_about_features.py
+++ b/tests/test_about_features.py
@@ -7,14 +7,12 @@ Feature: About Page
 
   Wireframe ref: Figma frame [33:919] About
 """
-import pytest
 from conftest import SITE_URL
 
 
 class TestAboutAnchors:
     """Scenario: Section anchors scroll to correct content."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
     def test_team_anchor_scrolls_to_team(self, page):
         """Given I navigate to about.html#team, Then the Team section is visible."""
         page.goto(f"{SITE_URL}/about.html#team", wait_until="domcontentloaded")
@@ -22,7 +20,6 @@ class TestAboutAnchors:
         assert heading.count() > 0
         assert heading.first.is_visible()
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
     def test_photo_gallery_anchor(self, page):
         """Given I navigate to about.html#photo-gallery, Then the Photo Gallery is visible."""
         page.goto(f"{SITE_URL}/about.html#photo-gallery", wait_until="domcontentloaded")
@@ -30,7 +27,6 @@ class TestAboutAnchors:
         assert heading.count() > 0
         assert heading.first.is_visible()
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — about anchors")
     def test_background_anchor(self, page):
         """Given I navigate to about.html#background-history, Then Background section is visible."""
         page.goto(f"{SITE_URL}/about.html#background-history", wait_until="domcontentloaded")
@@ -41,7 +37,6 @@ class TestAboutAnchors:
 class TestAboutPILinks:
     """Scenario: PI names link to ORCID profiles."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — PI ORCID links")
     def test_pi_names_have_orcid_links(self, page):
         """Given I am on the about page, Then each PI name links to an ORCID profile."""
         page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
@@ -52,7 +47,6 @@ class TestAboutPILinks:
 class TestAboutGallery:
     """Scenario: Photo gallery displays workshop and facility images."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — gallery images")
     def test_gallery_has_images(self, page):
         """Given I am on the about page, Then the photo gallery has at least 6 images."""
         page.goto(f"{SITE_URL}/about.html#photo-gallery", wait_until="domcontentloaded")
@@ -66,7 +60,6 @@ class TestAboutGallery:
 class TestAboutContributors:
     """Scenario: Contributors section lists project participants."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — contributors list")
     def test_contributors_section_expandable(self, page):
         """Given I am on the about page, Then I can expand the Contributors section."""
         page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")

--- a/tests/test_footer_links.py
+++ b/tests/test_footer_links.py
@@ -6,28 +6,24 @@ Feature: Footer and External Links
 
   Wireframe ref: Figma frame [33:425] (footer visible on all frames)
 """
-import pytest
 from conftest import SITE_URL
 
 
 class TestFooterContent:
     """Scenario: Footer displays NSF funding acknowledgement."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer content")
     def test_footer_has_nsf_grant_numbers(self, page):
         """Given I am on any page, Then I see NSF grant numbers in the footer."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
         footer = page.locator("footer, .page-footer")
         assert footer.get_by_text("2004839").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer content")
     def test_footer_has_copyright(self, page):
         """And the footer contains a copyright notice."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
         footer = page.locator("footer, .page-footer")
         assert footer.get_by_text("Copyright").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer disclaimer")
     def test_footer_has_disclaimer(self, page):
         """And the footer includes the NSF disclaimer."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
@@ -38,7 +34,6 @@ class TestFooterContent:
 class TestExternalLinks:
     """Scenario: Navbar external links point to correct destinations."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — external links")
     def test_github_icon_links_to_isamplesorg(self, page):
         """Given I am on any page, Then the GitHub icon links to isamplesorg."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
@@ -47,7 +42,6 @@ class TestExternalLinks:
         href = gh_link.get_attribute("href")
         assert "github.com/isamplesorg" in href
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — external links")
     def test_slack_icon_links_to_workspace(self, page):
         """And the Slack icon links to the iSamples workspace."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
@@ -58,7 +52,6 @@ class TestExternalLinks:
 class TestMetadataModelLink:
     """Scenario: Metadata Model external link opens correctly."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — metadata model link")
     def test_metadata_model_link_exists(self, page):
         """Given I navigate to Architecture, Then Metadata Model links to external site."""
         page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")

--- a/tests/test_footer_links.py
+++ b/tests/test_footer_links.py
@@ -1,0 +1,66 @@
+"""
+Feature: Footer and External Links
+  As a visitor on any page
+  I want to see consistent footer information and working external links
+  So that I can find funding info, legal notices, and related resources
+
+  Wireframe ref: Figma frame [33:425] (footer visible on all frames)
+"""
+import pytest
+from conftest import SITE_URL
+
+
+class TestFooterContent:
+    """Scenario: Footer displays NSF funding acknowledgement."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer content")
+    def test_footer_has_nsf_grant_numbers(self, page):
+        """Given I am on any page, Then I see NSF grant numbers in the footer."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        footer = page.locator("footer, .page-footer")
+        assert footer.get_by_text("2004839").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer content")
+    def test_footer_has_copyright(self, page):
+        """And the footer contains a copyright notice."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        footer = page.locator("footer, .page-footer")
+        assert footer.get_by_text("Copyright").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — footer disclaimer")
+    def test_footer_has_disclaimer(self, page):
+        """And the footer includes the NSF disclaimer."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        footer = page.locator("footer, .page-footer")
+        assert footer.get_by_text("not necessarily reflect").count() > 0
+
+
+class TestExternalLinks:
+    """Scenario: Navbar external links point to correct destinations."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — external links")
+    def test_github_icon_links_to_isamplesorg(self, page):
+        """Given I am on any page, Then the GitHub icon links to isamplesorg."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        gh_link = page.locator("a[href*='github.com/isamplesorg']").first
+        assert gh_link is not None
+        href = gh_link.get_attribute("href")
+        assert "github.com/isamplesorg" in href
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — external links")
+    def test_slack_icon_links_to_workspace(self, page):
+        """And the Slack icon links to the iSamples workspace."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        slack_link = page.locator("a[href*='isamples.slack.com']")
+        assert slack_link.count() > 0
+
+
+class TestMetadataModelLink:
+    """Scenario: Metadata Model external link opens correctly."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — metadata model link")
+    def test_metadata_model_link_exists(self, page):
+        """Given I navigate to Architecture, Then Metadata Model links to external site."""
+        page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")
+        link = page.locator("a[href*='isamplesorg.github.io/metadata']")
+        assert link.count() > 0

--- a/tests/test_homepage_features.py
+++ b/tests/test_homepage_features.py
@@ -1,0 +1,68 @@
+"""
+Feature: Homepage
+  As a visitor to iSamples.org
+  I want to see an engaging overview of the project
+  So that I understand what iSamples offers and can start exploring
+
+  Wireframe ref: Figma frame [33:425] Home
+"""
+import pytest
+from conftest import SITE_URL
+
+
+class TestHomepageShowcase:
+    """Scenario: Showcase gallery displays real sample images."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — showcase gallery")
+    def test_showcase_has_four_images(self, page):
+        """Given I am on the homepage, Then I should see 4 showcase images."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        images = page.locator(".quarto-figure img, .lightbox img")
+        assert images.count() >= 4
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — showcase alt text")
+    def test_showcase_images_have_alt_text(self, page):
+        """And each showcase image should have alt text."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        images = page.locator(".quarto-figure img, .lightbox img")
+        for i in range(images.count()):
+            alt = images.nth(i).get_attribute("alt")
+            assert alt and len(alt) > 0, f"Image {i} missing alt text"
+
+
+class TestHomepageCallouts:
+    """Scenario: Collapsible callouts explain the project."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
+    def test_has_what_is_isamples_callout(self, page):
+        """Given I am on the homepage, Then I should see a 'What is iSamples?' callout."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("What is iSamples").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
+    def test_has_how_can_i_access_callout(self, page):
+        """And I should see a 'How can I access it?' callout."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("How can I access").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
+    def test_has_why_browser_based_callout(self, page):
+        """And I should see a 'Why browser-based?' callout."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("Why browser-based").count() > 0
+
+
+class TestHomepageHero:
+    """Scenario: Hero section draws visitors in."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — hero stats")
+    def test_hero_shows_sample_count(self, page):
+        """Given I am on the homepage, Then I should see '6.7 million' in the stats."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("6.7 million").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — hero stats")
+    def test_hero_shows_repository_count(self, page):
+        """And I should see '4 repositories'."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("4 repositories").count() > 0

--- a/tests/test_homepage_features.py
+++ b/tests/test_homepage_features.py
@@ -20,7 +20,6 @@ class TestHomepageShowcase:
         images = page.locator(".quarto-figure img, .lightbox img")
         assert images.count() >= 4
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — showcase alt text")
     def test_showcase_images_have_alt_text(self, page):
         """And each showcase image should have alt text."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
@@ -33,19 +32,16 @@ class TestHomepageShowcase:
 class TestHomepageCallouts:
     """Scenario: Collapsible callouts explain the project."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
     def test_has_what_is_isamples_callout(self, page):
         """Given I am on the homepage, Then I should see a 'What is iSamples?' callout."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
         assert page.get_by_text("What is iSamples").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
     def test_has_how_can_i_access_callout(self, page):
         """And I should see a 'How can I access it?' callout."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
         assert page.get_by_text("How can I access").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — homepage callouts")
     def test_has_why_browser_based_callout(self, page):
         """And I should see a 'Why browser-based?' callout."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
@@ -55,13 +51,11 @@ class TestHomepageCallouts:
 class TestHomepageHero:
     """Scenario: Hero section draws visitors in."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — hero stats")
     def test_hero_shows_sample_count(self, page):
         """Given I am on the homepage, Then I should see '6.7 million' in the stats."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
         assert page.get_by_text("6.7 million").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — hero stats")
     def test_hero_shows_repository_count(self, page):
         """And I should see '4 repositories'."""
         page.goto(SITE_URL, wait_until="domcontentloaded")

--- a/tests/test_homepage_features.py
+++ b/tests/test_homepage_features.py
@@ -6,24 +6,22 @@ Feature: Homepage
 
   Wireframe ref: Figma frame [33:425] Home
 """
-import pytest
 from conftest import SITE_URL
 
 
 class TestHomepageShowcase:
     """Scenario: Showcase gallery displays real sample images."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — showcase gallery")
     def test_showcase_has_four_images(self, page):
         """Given I am on the homepage, Then I should see 4 showcase images."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        images = page.locator(".quarto-figure img, .lightbox img")
+        images = page.locator(".quarto-layout-cell img[data-group='showcase']")
         assert images.count() >= 4
 
     def test_showcase_images_have_alt_text(self, page):
         """And each showcase image should have alt text."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        images = page.locator(".quarto-figure img, .lightbox img")
+        images = page.locator(".quarto-layout-cell img[data-group='showcase']")
         for i in range(images.count()):
             alt = images.nth(i).get_attribute("alt")
             assert alt and len(alt) > 0, f"Image {i} missing alt text"

--- a/tests/test_navbar_dropdowns.py
+++ b/tests/test_navbar_dropdowns.py
@@ -1,0 +1,91 @@
+"""
+Feature: Navbar Dropdown Menus
+  As a visitor navigating iSamples
+  I want dropdown menus on the navbar to reveal sub-pages
+  So that I can quickly reach any section without using the sidebar
+
+  Wireframe ref: Figma frame [33:425] Home (6-item navbar)
+  Implementation: PR #103
+"""
+import pytest
+from conftest import SITE_URL
+
+
+class TestHowToUseDropdown:
+    """Scenario: How to Use dropdown shows 5 sub-items."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_how_to_use_dropdown_has_overview(self, page):
+        """Given I hover over How to Use, Then I see Overview."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("How to Use").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Overview").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_how_to_use_dropdown_has_deep_dive(self, page):
+        """And I see Deep-Dive Analysis."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("How to Use").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Deep-Dive Analysis").count() > 0
+
+
+class TestAboutDropdown:
+    """Scenario: About dropdown shows 4 sub-items."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_about_dropdown_has_objectives(self, page):
+        """Given I hover over About, Then I see Objectives."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("About", exact=True).hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Objectives").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_about_dropdown_has_pis(self, page):
+        """And I see PIs and Contributors."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("About", exact=True).hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("PIs and Contributors").count() > 0
+
+
+class TestArchitectureDropdown:
+    """Scenario: Architecture & Vocabularies dropdown shows sub-items."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_architecture_dropdown_has_requirements(self, page):
+        """Given I hover over Architecture, Then I see Requirements."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("Architecture").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Requirements").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_architecture_dropdown_has_vocabularies(self, page):
+        """And I see Vocabularies."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("Architecture").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Vocabularies").count() > 0
+
+
+class TestResearchDropdown:
+    """Scenario: Research & Resources dropdown shows sub-items."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_research_dropdown_has_publications(self, page):
+        """Given I hover over Research, Then I see Publications & Conferences."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("Research").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Publications").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
+    def test_research_dropdown_has_zenodo(self, page):
+        """And I see Zenodo Community."""
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        page.locator(".navbar").get_by_text("Research").hover()
+        dropdown = page.locator(".dropdown-menu:visible")
+        assert dropdown.get_by_text("Zenodo").count() > 0

--- a/tests/test_navbar_dropdowns.py
+++ b/tests/test_navbar_dropdowns.py
@@ -7,85 +7,78 @@ Feature: Navbar Dropdown Menus
   Wireframe ref: Figma frame [33:425] Home (6-item navbar)
   Implementation: PR #103
 """
-import pytest
 from conftest import SITE_URL
+
+
+def _open_dropdown(page, label, exact=False):
+    """Click a Bootstrap 5 navbar dropdown toggle to reveal its menu."""
+    # Structure: li.nav-item.dropdown > a.dropdown-toggle > span.menu-text
+    dropdown_li = page.locator(f".navbar li.dropdown:has(a:has-text('{label}'))")
+    dropdown_li.locator("a.dropdown-toggle").click()
+    menu = dropdown_li.locator("ul.dropdown-menu")
+    menu.wait_for(state="visible", timeout=3000)
+    return menu
 
 
 class TestHowToUseDropdown:
     """Scenario: How to Use dropdown shows 5 sub-items."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_how_to_use_dropdown_has_overview(self, page):
-        """Given I hover over How to Use, Then I see Overview."""
+        """Given I click How to Use, Then I see Overview."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("How to Use").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Overview").count() > 0
+        menu = _open_dropdown(page, "How to Use")
+        assert menu.get_by_text("Overview").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_how_to_use_dropdown_has_deep_dive(self, page):
         """And I see Deep-Dive Analysis."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("How to Use").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Deep-Dive Analysis").count() > 0
+        menu = _open_dropdown(page, "How to Use")
+        assert menu.get_by_text("Deep-Dive Analysis").count() > 0
 
 
 class TestAboutDropdown:
     """Scenario: About dropdown shows 4 sub-items."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_about_dropdown_has_objectives(self, page):
-        """Given I hover over About, Then I see Objectives."""
+        """Given I click About, Then I see Objectives."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("About", exact=True).hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Objectives").count() > 0
+        menu = _open_dropdown(page, "About", exact=True)
+        assert menu.get_by_text("Objectives").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_about_dropdown_has_pis(self, page):
         """And I see PIs and Contributors."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("About", exact=True).hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("PIs and Contributors").count() > 0
+        menu = _open_dropdown(page, "About", exact=True)
+        assert menu.get_by_text("PIs and Contributors").count() > 0
 
 
 class TestArchitectureDropdown:
     """Scenario: Architecture & Vocabularies dropdown shows sub-items."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_architecture_dropdown_has_requirements(self, page):
-        """Given I hover over Architecture, Then I see Requirements."""
+        """Given I click Architecture, Then I see Requirements."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("Architecture").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Requirements").count() > 0
+        menu = _open_dropdown(page, "Architecture")
+        assert menu.get_by_text("Requirements").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_architecture_dropdown_has_vocabularies(self, page):
         """And I see Vocabularies."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("Architecture").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Vocabularies").count() > 0
+        menu = _open_dropdown(page, "Architecture")
+        assert menu.get_by_text("Vocabularies").count() > 0
 
 
 class TestResearchDropdown:
     """Scenario: Research & Resources dropdown shows sub-items."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_research_dropdown_has_publications(self, page):
-        """Given I hover over Research, Then I see Publications & Conferences."""
+        """Given I click Research, Then I see Publications & Conferences."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("Research").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Publications").count() > 0
+        menu = _open_dropdown(page, "Research")
+        assert menu.get_by_text("Publications").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — navbar dropdowns")
     def test_research_dropdown_has_zenodo(self, page):
         """And I see Zenodo Community."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        page.locator(".navbar").get_by_text("Research").hover()
-        dropdown = page.locator(".dropdown-menu:visible")
-        assert dropdown.get_by_text("Zenodo").count() > 0
+        menu = _open_dropdown(page, "Research")
+        assert menu.get_by_text("Zenodo").count() > 0

--- a/tests/test_research_resources.py
+++ b/tests/test_research_resources.py
@@ -1,0 +1,80 @@
+"""
+Feature: Research & Resources Page
+  As a researcher interested in iSamples outputs
+  I want to find publications, datasets, and source code in one place
+  So that I can cite the project and build on its work
+
+  Wireframe ref: Figma frame [130:1156] Research & Resources
+"""
+import pytest
+from conftest import SITE_URL
+
+
+PUBS_URL = f"{SITE_URL}/pubs.html"
+
+
+class TestResearchPageSections:
+    """Scenario: All research sections appear on the unified page."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
+    def test_has_publications_section(self, page):
+        """Given I am on the research page, Then I see a Publications section."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        assert page.locator("h2:has-text('Publications')").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
+    def test_has_zenodo_section(self, page):
+        """And I see a Zenodo Community section."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        assert page.locator("h2:has-text('Zenodo')").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
+    def test_has_github_section(self, page):
+        """And I see a GitHub Repositories section."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        assert page.locator("h2:has-text('GitHub')").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
+    def test_github_table_has_repos(self, page):
+        """And the GitHub section lists repository links."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        repo_links = page.locator("a[href*='github.com/isamplesorg']")
+        assert repo_links.count() >= 3
+
+
+class TestResearchMediaEmbeds:
+    """Scenario: Conference presentations are watchable and downloadable."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
+    def test_youtube_embed_is_responsive(self, page):
+        """Given I am on the research page, Then the YouTube embed has width/height."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        iframe = page.locator("iframe[src*='youtube']")
+        assert iframe.count() > 0
+        box = iframe.first.bounding_box()
+        assert box and box["width"] > 200
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
+    def test_pdf_embed_loads(self, page):
+        """And the PDF slides embed is present."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        pdf = page.locator("embed[type='application/pdf']")
+        assert pdf.count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
+    def test_pdf_download_link(self, page):
+        """And a download link for the PDF slides exists."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        download = page.locator("a[href*='.pdf']:has-text('Download')")
+        assert download.count() > 0
+
+
+class TestResearchBibliography:
+    """Scenario: Publications section renders bibliography entries."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — bibliography")
+    def test_bibliography_has_entries(self, page):
+        """Given I am on the research page, Then I see at least one citation."""
+        page.goto(PUBS_URL, wait_until="domcontentloaded")
+        refs = page.locator("#refs .csl-entry, .references .csl-entry")
+        assert refs.count() > 0

--- a/tests/test_research_resources.py
+++ b/tests/test_research_resources.py
@@ -6,7 +6,6 @@ Feature: Research & Resources Page
 
   Wireframe ref: Figma frame [130:1156] Research & Resources
 """
-import pytest
 from conftest import SITE_URL
 
 
@@ -16,25 +15,21 @@ PUBS_URL = f"{SITE_URL}/pubs.html"
 class TestResearchPageSections:
     """Scenario: All research sections appear on the unified page."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
     def test_has_publications_section(self, page):
         """Given I am on the research page, Then I see a Publications section."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
         assert page.locator("h2:has-text('Publications')").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
     def test_has_zenodo_section(self, page):
         """And I see a Zenodo Community section."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
         assert page.locator("h2:has-text('Zenodo')").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
     def test_has_github_section(self, page):
         """And I see a GitHub Repositories section."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
         assert page.locator("h2:has-text('GitHub')").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — unified research page")
     def test_github_table_has_repos(self, page):
         """And the GitHub section lists repository links."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
@@ -45,7 +40,6 @@ class TestResearchPageSections:
 class TestResearchMediaEmbeds:
     """Scenario: Conference presentations are watchable and downloadable."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
     def test_youtube_embed_is_responsive(self, page):
         """Given I am on the research page, Then the YouTube embed has width/height."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
@@ -54,14 +48,12 @@ class TestResearchMediaEmbeds:
         box = iframe.first.bounding_box()
         assert box and box["width"] > 200
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
     def test_pdf_embed_loads(self, page):
         """And the PDF slides embed is present."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
         pdf = page.locator("embed[type='application/pdf']")
         assert pdf.count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — media embeds")
     def test_pdf_download_link(self, page):
         """And a download link for the PDF slides exists."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")
@@ -72,7 +64,6 @@ class TestResearchMediaEmbeds:
 class TestResearchBibliography:
     """Scenario: Publications section renders bibliography entries."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — bibliography")
     def test_bibliography_has_entries(self, page):
         """Given I am on the research page, Then I see at least one citation."""
         page.goto(PUBS_URL, wait_until="domcontentloaded")

--- a/tests/test_responsive.py
+++ b/tests/test_responsive.py
@@ -6,14 +6,12 @@ Feature: Responsive Layout
 
   Wireframe ref: Figma frame [33:425] (implied responsive behavior)
 """
-import pytest
 from conftest import SITE_URL
 
 
 class TestMobileNavigation:
     """Scenario: Navbar collapses to hamburger menu on small screens."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — mobile nav")
     def test_hamburger_visible_on_mobile(self, page):
         """Given I am on a 375px-wide screen, Then I see a hamburger menu button."""
         page.set_viewport_size({"width": 375, "height": 812})
@@ -22,7 +20,6 @@ class TestMobileNavigation:
         assert toggle.count() > 0
         assert toggle.first.is_visible()
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — mobile nav")
     def test_sidebar_hidden_on_mobile(self, page):
         """And the sidebar is not visible on mobile."""
         page.set_viewport_size({"width": 375, "height": 812})
@@ -35,7 +32,6 @@ class TestMobileNavigation:
 class TestTabletLayout:
     """Scenario: Content is readable at tablet width."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tablet layout")
     def test_no_horizontal_scroll_at_768(self, page):
         """Given I am on a 768px-wide screen, Then there is no horizontal scrollbar."""
         page.set_viewport_size({"width": 768, "height": 1024})
@@ -50,7 +46,6 @@ class TestTabletLayout:
 class TestDesktopLayout:
     """Scenario: Full navigation visible on desktop."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — desktop layout")
     def test_navbar_expanded_on_desktop(self, page):
         """Given I am on a 1280px-wide screen, Then the navbar items are visible."""
         page.set_viewport_size({"width": 1280, "height": 900})
@@ -58,7 +53,6 @@ class TestDesktopLayout:
         navbar = page.locator(".navbar")
         assert navbar.get_by_text("About").first.is_visible()
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — desktop layout")
     def test_sidebar_visible_on_desktop(self, page):
         """And the sidebar is visible on inner pages."""
         page.set_viewport_size({"width": 1280, "height": 900})

--- a/tests/test_responsive.py
+++ b/tests/test_responsive.py
@@ -1,0 +1,68 @@
+"""
+Feature: Responsive Layout
+  As a visitor on a tablet or phone
+  I want the site to adapt to my screen size
+  So that I can read content and navigate without horizontal scrolling
+
+  Wireframe ref: Figma frame [33:425] (implied responsive behavior)
+"""
+import pytest
+from conftest import SITE_URL
+
+
+class TestMobileNavigation:
+    """Scenario: Navbar collapses to hamburger menu on small screens."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — mobile nav")
+    def test_hamburger_visible_on_mobile(self, page):
+        """Given I am on a 375px-wide screen, Then I see a hamburger menu button."""
+        page.set_viewport_size({"width": 375, "height": 812})
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        toggle = page.locator(".navbar-toggler, button[aria-label='Toggle navigation']")
+        assert toggle.count() > 0
+        assert toggle.first.is_visible()
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — mobile nav")
+    def test_sidebar_hidden_on_mobile(self, page):
+        """And the sidebar is not visible on mobile."""
+        page.set_viewport_size({"width": 375, "height": 812})
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        if sidebar.count() > 0:
+            assert not sidebar.first.is_visible()
+
+
+class TestTabletLayout:
+    """Scenario: Content is readable at tablet width."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tablet layout")
+    def test_no_horizontal_scroll_at_768(self, page):
+        """Given I am on a 768px-wide screen, Then there is no horizontal scrollbar."""
+        page.set_viewport_size({"width": 768, "height": 1024})
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        scroll_width = page.evaluate("document.documentElement.scrollWidth")
+        viewport_width = page.evaluate("document.documentElement.clientWidth")
+        assert scroll_width <= viewport_width + 5, (
+            f"Horizontal overflow: scrollWidth={scroll_width}, viewport={viewport_width}"
+        )
+
+
+class TestDesktopLayout:
+    """Scenario: Full navigation visible on desktop."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — desktop layout")
+    def test_navbar_expanded_on_desktop(self, page):
+        """Given I am on a 1280px-wide screen, Then the navbar items are visible."""
+        page.set_viewport_size({"width": 1280, "height": 900})
+        page.goto(SITE_URL, wait_until="domcontentloaded")
+        navbar = page.locator(".navbar")
+        assert navbar.get_by_text("About").first.is_visible()
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — desktop layout")
+    def test_sidebar_visible_on_desktop(self, page):
+        """And the sidebar is visible on inner pages."""
+        page.set_viewport_size({"width": 1280, "height": 900})
+        page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        assert sidebar.count() > 0
+        assert sidebar.first.is_visible()

--- a/tests/test_tutorials_landing.py
+++ b/tests/test_tutorials_landing.py
@@ -1,0 +1,74 @@
+"""
+Feature: How to Use / Tutorials Landing
+  As a new user exploring iSamples
+  I want a guided overview of the available tutorials
+  So that I can choose the right starting point for my skill level
+
+  Wireframe ref: Figma frame [33:1005] How to Use
+"""
+import pytest
+from conftest import SITE_URL
+
+
+HOW_TO_USE_URL = f"{SITE_URL}/how-to-use.html"
+
+
+class TestHowToUseLanding:
+    """Scenario: Landing page lists all tutorial pathways."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
+    def test_has_deep_dive_link(self, page):
+        """Given I am on the How to Use page, Then I see a link to Deep-Dive Analysis."""
+        page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
+        link = page.locator("a:has-text('Deep-Dive')")
+        assert link.count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
+    def test_has_globe_viz_link(self, page):
+        """And I see a link to the 3D Globe Visualization."""
+        page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
+        link = page.locator("a:has-text('Globe')")
+        assert link.count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
+    def test_has_search_explorer_link(self, page):
+        """And I see a link to the Search Explorer."""
+        page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
+        link = page.locator("a:has-text('Explorer')")
+        assert link.count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
+    def test_has_narrow_vs_wide_link(self, page):
+        """And I see a link to Narrow vs Wide."""
+        page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
+        link = page.locator("a:has-text('Narrow')")
+        assert link.count() > 0
+
+
+class TestTutorialPageLoads:
+    """Scenario: Each tutorial page loads without JavaScript errors."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tutorial page health")
+    def test_deep_dive_loads(self, page):
+        """Given I navigate to the Deep-Dive tutorial, Then no JS errors appear."""
+        errors = []
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.goto(
+            f"{SITE_URL}/tutorials/zenodo_isamples_analysis.html",
+            wait_until="domcontentloaded",
+        )
+        assert page.title() != ""
+        # Allow known non-critical errors but flag unexpected ones
+        critical = [e for e in errors if "TypeError" in e or "ReferenceError" in e]
+        assert len(critical) == 0, f"JS errors: {critical}"
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tutorial page health")
+    def test_globe_viz_loads(self, page):
+        """Given I navigate to the 3D Globe page, Then the Cesium container exists."""
+        page.goto(
+            f"{SITE_URL}/tutorials/progressive_globe.html",
+            wait_until="domcontentloaded",
+            timeout=30000,
+        )
+        cesium = page.locator("#cesiumContainer, .cesium-viewer")
+        assert cesium.count() > 0

--- a/tests/test_tutorials_landing.py
+++ b/tests/test_tutorials_landing.py
@@ -6,7 +6,6 @@ Feature: How to Use / Tutorials Landing
 
   Wireframe ref: Figma frame [33:1005] How to Use
 """
-import pytest
 from conftest import SITE_URL
 
 
@@ -16,28 +15,24 @@ HOW_TO_USE_URL = f"{SITE_URL}/how-to-use.html"
 class TestHowToUseLanding:
     """Scenario: Landing page lists all tutorial pathways."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
     def test_has_deep_dive_link(self, page):
         """Given I am on the How to Use page, Then I see a link to Deep-Dive Analysis."""
         page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
         link = page.locator("a:has-text('Deep-Dive')")
         assert link.count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
     def test_has_globe_viz_link(self, page):
         """And I see a link to the 3D Globe Visualization."""
         page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
         link = page.locator("a:has-text('Globe')")
         assert link.count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
     def test_has_search_explorer_link(self, page):
         """And I see a link to the Search Explorer."""
         page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
         link = page.locator("a:has-text('Explorer')")
         assert link.count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — tutorials landing")
     def test_has_narrow_vs_wide_link(self, page):
         """And I see a link to Narrow vs Wide."""
         page.goto(HOW_TO_USE_URL, wait_until="domcontentloaded")
@@ -48,7 +43,6 @@ class TestHowToUseLanding:
 class TestTutorialPageLoads:
     """Scenario: Each tutorial page loads without JavaScript errors."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tutorial page health")
     def test_deep_dive_loads(self, page):
         """Given I navigate to the Deep-Dive tutorial, Then no JS errors appear."""
         errors = []
@@ -62,7 +56,6 @@ class TestTutorialPageLoads:
         critical = [e for e in errors if "TypeError" in e or "ReferenceError" in e]
         assert len(critical) == 0, f"JS errors: {critical}"
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — tutorial page health")
     def test_globe_viz_loads(self, page):
         """Given I navigate to the 3D Globe page, Then the Cesium container exists."""
         page.goto(

--- a/tests/test_vocabularies.py
+++ b/tests/test_vocabularies.py
@@ -6,11 +6,11 @@ Feature: Vocabularies Page
 
   Wireframe ref: Figma frame [130:1300] Architecture & Vocabularies
 """
-import pytest
 from conftest import SITE_URL
 
 
 VOCAB_URL = f"{SITE_URL}/models/index.html"
+MATERIAL_TYPE_URL = f"{SITE_URL}/models/generated/vocabularies/material_type.html"
 
 
 class TestVocabularyIndex:
@@ -41,17 +41,16 @@ class TestVocabularyIndex:
 class TestVocabularyDetail:
     """Scenario: Individual vocabulary pages show concept hierarchy."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary detail page")
     def test_material_type_has_hierarchy(self, page):
-        """Given I navigate to a vocabulary detail page, Then I see a concept tree."""
-        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
-        # SKOS concepts should render as nested lists or tree
-        concepts = page.locator("li a, .concept-label")
+        """Given I navigate to a vocabulary detail page, Then I see concept sections."""
+        page.goto(MATERIAL_TYPE_URL, wait_until="domcontentloaded")
+        # Vocabulary pages render concepts as numbered sections (h2, h3, h4)
+        concepts = page.locator("section[id] h2, section[id] h3, section[id] h4")
         assert concepts.count() >= 5
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary definitions")
     def test_concepts_have_definitions(self, page):
-        """And each concept should have a definition or description."""
-        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
-        definitions = page.locator("dd, .concept-definition, blockquote")
+        """And each concept should have a definition."""
+        page.goto(MATERIAL_TYPE_URL, wait_until="domcontentloaded")
+        # Definitions rendered as <p><strong>Definition: </strong>...</p>
+        definitions = page.locator("p:has(strong:has-text('Definition'))")
         assert definitions.count() >= 3

--- a/tests/test_vocabularies.py
+++ b/tests/test_vocabularies.py
@@ -16,25 +16,21 @@ VOCAB_URL = f"{SITE_URL}/models/index.html"
 class TestVocabularyIndex:
     """Scenario: Vocabulary index lists all SKOS vocabularies."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
     def test_has_material_type_vocab(self, page):
         """Given I am on the vocabularies page, Then I see Material Type."""
         page.goto(VOCAB_URL, wait_until="domcontentloaded")
         assert page.get_by_text("Material Type").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
     def test_has_specimen_type_vocab(self, page):
         """Given I am on the vocabularies page, Then I see Specimen Type."""
         page.goto(VOCAB_URL, wait_until="domcontentloaded")
         assert page.get_by_text("Specimen Type").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
     def test_has_sampled_feature_vocab(self, page):
         """Given I am on the vocabularies page, Then I see Sampled Feature."""
         page.goto(VOCAB_URL, wait_until="domcontentloaded")
         assert page.get_by_text("Sampled Feature").count() > 0
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary readability")
     def test_vocabulary_links_resolve(self, page):
         """And each vocabulary name links to its detail page."""
         page.goto(VOCAB_URL, wait_until="domcontentloaded")

--- a/tests/test_vocabularies.py
+++ b/tests/test_vocabularies.py
@@ -1,0 +1,61 @@
+"""
+Feature: Vocabularies Page
+  As a data modeler or repository implementer
+  I want to browse iSamples controlled vocabularies
+  So that I can understand and apply the classification schemes
+
+  Wireframe ref: Figma frame [130:1300] Architecture & Vocabularies
+"""
+import pytest
+from conftest import SITE_URL
+
+
+VOCAB_URL = f"{SITE_URL}/models/index.html"
+
+
+class TestVocabularyIndex:
+    """Scenario: Vocabulary index lists all SKOS vocabularies."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
+    def test_has_material_type_vocab(self, page):
+        """Given I am on the vocabularies page, Then I see Material Type."""
+        page.goto(VOCAB_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("Material Type").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
+    def test_has_specimen_type_vocab(self, page):
+        """Given I am on the vocabularies page, Then I see Specimen Type."""
+        page.goto(VOCAB_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("Specimen Type").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary index page")
+    def test_has_sampled_feature_vocab(self, page):
+        """Given I am on the vocabularies page, Then I see Sampled Feature."""
+        page.goto(VOCAB_URL, wait_until="domcontentloaded")
+        assert page.get_by_text("Sampled Feature").count() > 0
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — vocabulary readability")
+    def test_vocabulary_links_resolve(self, page):
+        """And each vocabulary name links to its detail page."""
+        page.goto(VOCAB_URL, wait_until="domcontentloaded")
+        vocab_links = page.locator("a[href*='models/']")
+        assert vocab_links.count() >= 3
+
+
+class TestVocabularyDetail:
+    """Scenario: Individual vocabulary pages show concept hierarchy."""
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary detail page")
+    def test_material_type_has_hierarchy(self, page):
+        """Given I navigate to a vocabulary detail page, Then I see a concept tree."""
+        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
+        # SKOS concepts should render as nested lists or tree
+        concepts = page.locator("li a, .concept-label")
+        assert concepts.count() >= 5
+
+    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary definitions")
+    def test_concepts_have_definitions(self, page):
+        """And each concept should have a definition or description."""
+        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
+        definitions = page.locator("dd, .concept-definition, blockquote")
+        assert definitions.count() >= 3


### PR DESCRIPTION
## Summary
- Fixes the 3 remaining xfail test stubs from PR #105 by correcting selectors to match actual rendered HTML
- **Homepage showcase**: `.quarto-layout-cell img[data-group='showcase']` (was `.quarto-figure img, .lightbox img`)
- **Vocabulary detail URL**: `models/generated/vocabularies/material_type.html` (was `models/materialType.html` — 404)
- **Vocabulary definitions**: `p:has(strong:has-text('Definition'))` (was `dd, .concept-definition, blockquote`)

## Test plan
- [x] `pytest tests/ -v` — **52 passed, 0 xfailed, 0 failed** in 24.78s

🤖 Generated with [Claude Code](https://claude.com/claude-code)