### PR TITLE
Fix last 3 xfail tests — all 52 now pass

### DIFF
--- a/tests/test_homepage_features.py
+++ b/tests/test_homepage_features.py
@@ -6,24 +6,22 @@ Feature: Homepage
 
   Wireframe ref: Figma frame [33:425] Home
 """
-import pytest
 from conftest import SITE_URL
 
 
 class TestHomepageShowcase:
     """Scenario: Showcase gallery displays real sample images."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P0 — showcase gallery")
     def test_showcase_has_four_images(self, page):
         """Given I am on the homepage, Then I should see 4 showcase images."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        images = page.locator(".quarto-figure img, .lightbox img")
+        images = page.locator(".quarto-layout-cell img[data-group='showcase']")
         assert images.count() >= 4
 
     def test_showcase_images_have_alt_text(self, page):
         """And each showcase image should have alt text."""
         page.goto(SITE_URL, wait_until="domcontentloaded")
-        images = page.locator(".quarto-figure img, .lightbox img")
+        images = page.locator(".quarto-layout-cell img[data-group='showcase']")
         for i in range(images.count()):
             alt = images.nth(i).get_attribute("alt")
             assert alt and len(alt) > 0, f"Image {i} missing alt text"

--- a/tests/test_vocabularies.py
+++ b/tests/test_vocabularies.py
@@ -6,11 +6,11 @@ Feature: Vocabularies Page
 
   Wireframe ref: Figma frame [130:1300] Architecture & Vocabularies
 """
-import pytest
 from conftest import SITE_URL
 
 
 VOCAB_URL = f"{SITE_URL}/models/index.html"
+MATERIAL_TYPE_URL = f"{SITE_URL}/models/generated/vocabularies/material_type.html"
 
 
 class TestVocabularyIndex:
@@ -41,17 +41,16 @@ class TestVocabularyIndex:
 class TestVocabularyDetail:
     """Scenario: Individual vocabulary pages show concept hierarchy."""
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary detail page")
     def test_material_type_has_hierarchy(self, page):
-        """Given I navigate to a vocabulary detail page, Then I see a concept tree."""
-        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
-        # SKOS concepts should render as nested lists or tree
-        concepts = page.locator("li a, .concept-label")
+        """Given I navigate to a vocabulary detail page, Then I see concept sections."""
+        page.goto(MATERIAL_TYPE_URL, wait_until="domcontentloaded")
+        # Vocabulary pages render concepts as numbered sections (h2, h3, h4)
+        concepts = page.locator("section[id] h2, section[id] h3, section[id] h4")
         assert concepts.count() >= 5
 
-    @pytest.mark.xfail(reason="Not yet tested: #104 P1 — vocabulary definitions")
     def test_concepts_have_definitions(self, page):
-        """And each concept should have a definition or description."""
-        page.goto(f"{SITE_URL}/models/materialType.html", wait_until="domcontentloaded")
-        definitions = page.locator("dd, .concept-definition, blockquote")
+        """And each concept should have a definition."""
+        page.goto(MATERIAL_TYPE_URL, wait_until="domcontentloaded")
+        # Definitions rendered as <p><strong>Definition: </strong>...</p>
+        definitions = page.locator("p:has(strong:has-text('Definition'))")
         assert definitions.count() >= 3


### PR DESCRIPTION
## Summary
- Fixes the 3 remaining xfail test stubs from PR #105 by correcting selectors to match actual rendered HTML
- **Homepage showcase**: `.quarto-layout-cell img[data-group='showcase']` (was `.quarto-figure img, .lightbox img`)
- **Vocabulary detail URL**: `models/generated/vocabularies/material_type.html` (was `models/materialType.html` — 404)
- **Vocabulary definitions**: `p:has(strong:has-text('Definition'))` (was `dd, .concept-definition, blockquote`)

## Test plan
- [x] `pytest tests/ -v` — **52 passed, 0 xfailed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)