### PR TITLE
Align sidebar with Figma wireframe

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -87,13 +87,16 @@ website:
           href: "about.qmd#photo-gallery"
         - text: "Background & History"
           href: "about.qmd#background-history"
-      - section: "Architecture and Vocabularies"
+      - section: "Architecture & Vocabularies"
         contents:
-          - design/index.qmd
-          - design/requirements.md
-          - text: Metadata Model
+          - href: design/index.qmd
+            text: Overview
+          - href: design/requirements.md
+            text: Requirements
+          - text: Schema
             href: "https://isamplesorg.github.io/metadata/"
-          - models/index.qmd
+          - href: models/index.qmd
+            text: Vocabularies
       - section: "Research & Resources"
         contents:
         - text: Publications & Conferences

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -14,7 +14,7 @@ class TestSidebarSections:
     def test_sidebar_shows_architecture_and_vocabularies(self, page):
         page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
         sidebar = page.locator(".sidebar-navigation")
-        assert sidebar.get_by_text("Architecture and Vocabularies").count() > 0
+        assert sidebar.get_by_text("Architecture & Vocabularies").count() > 0
 
     def test_sidebar_does_not_show_old_information_architecture(self, page):
         page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
@@ -92,6 +92,30 @@ class TestSidebarAbout:
         page.goto(f"{SITE_URL}/about.html", wait_until="domcontentloaded")
         sidebar = page.locator(".sidebar-navigation")
         assert sidebar.get_by_text("Background & History").count() > 0
+
+
+class TestSidebarArchitectureVocabularies:
+    """Architecture & Vocabularies should have 4 items matching wireframe."""
+
+    def test_has_overview(self, page):
+        page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        assert sidebar.get_by_text("Overview", exact=True).count() > 0
+
+    def test_has_requirements(self, page):
+        page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        assert sidebar.get_by_text("Requirements", exact=True).count() > 0
+
+    def test_has_schema(self, page):
+        page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        assert sidebar.get_by_text("Schema", exact=True).count() > 0
+
+    def test_has_vocabularies(self, page):
+        page.goto(f"{SITE_URL}/design/index.html", wait_until="domcontentloaded")
+        sidebar = page.locator(".sidebar-navigation")
+        assert sidebar.get_by_text("Vocabularies", exact=True).count() > 0
 
 
 class TestSidebarResearchResources:


### PR DESCRIPTION
## Summary
- Renames "Architecture and Vocabularies" → "Architecture & Vocabularies" in sidebar
- Adds explicit text labels matching Figma: Overview, Requirements, Schema, Vocabularies
- Renames "Metadata Model" → "Schema" per wireframe
- Adds 4 new sidebar tests for Architecture & Vocabularies sub-items

## Figma vs Current → Fixed

| Figma wireframe | Was | Now |
|----------------|-----|-----|
| Architecture **&** Vocabularies | Architecture **and** Vocabularies | Architecture **&** Vocabularies |
| Overview | (raw file title) | Overview |
| Requirements | (raw file title) | Requirements |
| Schema | Metadata Model | Schema |
| Vocabularies | iSamples Vocabularies | Vocabularies |

## Test plan
- [ ] `pytest tests/test_navigation.py -v` passes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)