### PR TITLE
Fix globe click-through to Interactive Explorer

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -9,7 +9,7 @@ page-layout: full
 
 ::: {.column-page}
 
-[![Explore 6.7 million samples on an interactive globe](assets/isamples_globe.webp){fig-alt="Animated rotating globe showing iSamples data points from 4 scientific repositories" width="100%"}](/tutorials/progressive_globe.html "Explore the interactive globe")
+[![Explore 6.7 million samples on an interactive globe](assets/isamples_globe.webp){fig-alt="Animated rotating globe showing iSamples data points from 4 scientific repositories" width="100%" .nolightbox}](/tutorials/progressive_globe.html "Explore the interactive globe")
 
 :::
 


### PR DESCRIPTION
## Summary
- The lightbox feature (#110) was intercepting the globe image link, preventing click-through to the Interactive Explorer
- Add `.nolightbox` class to the globe image to preserve the navigation link

## Test plan
- [x] Rendered HTML has `<a href="./tutorials/progressive_globe.html">` wrapping the globe image
- [ ] Verify click-through works on live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)