### PR TITLE
Fix palette import path for OJS runtime

### DIFF
--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -38,7 +38,7 @@ cross_filter_url = "https://data.isamples.org/isamples_202601_facet_cross_filter
 sample_facets_url = "https://data.isamples.org/isamples_202601_sample_facets_v2.parquet"
 
 // Source color scheme — imported from canonical palette (issue #113)
-_palette = await import('../assets/js/source-palette.js')
+_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
 SOURCE_COLORS = _palette.SOURCE_COLORS
 
 // Cesium colors

--- a/tutorials/parquet_cesium_isamples_wide.qmd
+++ b/tutorials/parquet_cesium_isamples_wide.qmd
@@ -96,7 +96,7 @@ viewof viewModeToggle = Inputs.radio(["clustered", "all points"], {
 ```{ojs}
 //| echo: false
 // Source color scheme — imported from canonical palette (issue #113)
-_palette = await import('../assets/js/source-palette.js')
+_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
 CLUSTER_COLORS = _palette.SOURCE_COLORS
 
 // H3 resolution based on camera height

--- a/tutorials/progressive_globe.qmd
+++ b/tutorials/progressive_globe.qmd
@@ -207,7 +207,7 @@ facets_url = `${R2_BASE}/isamples_202601_sample_facets.parquet`
 facet_summaries_url = `${R2_BASE}/isamples_202601_facet_summaries.parquet`
 
 // Canonical palette — see issue #113
-_palette = await import('../assets/js/source-palette.js')
+_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
 SOURCE_COLORS = _palette.SOURCE_COLORS
 SOURCE_NAMES = _palette.SOURCE_NAMES
 


### PR DESCRIPTION
Follow-up to #114.

OJS resolves relative imports against its own runtime path (`/site_libs/quarto-ojs/`), not the page URL, so `../assets/js/source-palette.js` was being fetched from `https://isamples.org/site_libs/assets/js/source-palette.js` (404) and breaking every OJS cell downstream.

Fix: compute an absolute URL from `document.baseURI`:

```js
_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
```

Verified with Playwright against a local render: module loads, `SOURCE_COLORS` exposed correctly.

## Test plan

- [x] `quarto render tutorials/progressive_globe.qmd` succeeds
- [x] Playwright: dynamic import of `/assets/js/source-palette.js` returns the expected palette
- [ ] Live site renders the globe (post-merge smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)