### PR TITLE
Add redirect stub for archived 3D Globe Visualization URL

### DIFF
--- a/tutorials/parquet_cesium_isamples_wide.qmd
+++ b/tutorials/parquet_cesium_isamples_wide.qmd
@@ -1,0 +1,19 @@
+---
+title: "3D Globe Visualization (moved)"
+format:
+  html:
+    include-in-header:
+      text: |
+        <meta http-equiv="refresh" content="0; url=/tutorials/progressive_globe.html">
+        <link rel="canonical" href="https://isamples.org/tutorials/progressive_globe.html">
+---
+
+This page has moved. The **3D Globe Visualization** has been superseded by the
+[**Interactive Explorer**](/tutorials/progressive_globe.html), which subsumes
+its functionality with zoom-adaptive H3 clustering and sample-level drilldown.
+
+If your browser does not redirect automatically, open
+[/tutorials/progressive_globe.html](/tutorials/progressive_globe.html).
+
+The original page is archived for historical reference at
+[/tutorials/archive/parquet_cesium_isamples_wide.html](/tutorials/archive/parquet_cesium_isamples_wide.html).


### PR DESCRIPTION
Follow-up to #116. Old URL `/tutorials/parquet_cesium_isamples_wide.html` was 404ing; add a meta-refresh stub redirecting to the Interactive Explorer with a visible fallback link and a pointer to the archived original.