### PR TITLE
Add Cloudflare Worker for data.isamples.org with immutable cache-control

### DIFF
--- a/workers/data-isamples-org/.gitignore
+++ b/workers/data-isamples-org/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/workers/data-isamples-org/README.md
+++ b/workers/data-isamples-org/README.md
@@ -1,0 +1,97 @@
+# `data.isamples.org` Worker
+
+A Cloudflare Worker that proxies the iSamples R2 bucket at
+`data.isamples.org` and — most importantly — adds a `Cache-Control` header
+so Cloudflare's edge and the user's browser can cache immutable parquet
+versions aggressively.
+
+## Why this exists
+
+The parquet files under `data.isamples.org` are filename-versioned
+(`isamples_202601_wide.parquet`, `isamples_202601_h3_summary_res4.parquet`,
+etc.) — the month appears in the filename, so content at a given URL never
+changes.
+
+Without a `Cache-Control` header, Cloudflare's edge does **not** cache these
+files, and browsers use unpredictable heuristic caching (often: re-fetch on
+every visit). This Worker fixes that by emitting:
+
+```
+Cache-Control: public, max-age=31536000, immutable
+```
+
+…for any path matching `^isamples_\d{6}_.*\.parquet$`, and a short 5-minute
+fallback for anything else.
+
+## What it does
+
+| Concern | How |
+| --- | --- |
+| R2 access | R2 bucket binding (`env.BUCKET`) — no public `r2.dev` hop |
+| Range requests | Parsed and forwarded; required for DuckDB-WASM |
+| CORS | `Access-Control-Allow-Origin: *`, exposes `Content-Range` etc. |
+| HEAD requests | Uses `BUCKET.head()` and returns headers only |
+| Immutable cache | `max-age=31536000, immutable` for versioned parquets |
+| Short cache fallback | `max-age=300` for anything else |
+
+## Deploying
+
+One-time setup (if not already done):
+
+```bash
+cd workers/data-isamples-org
+npm install -g wrangler    # or: npx wrangler ...
+wrangler login             # opens browser, auth to isamples.org account
+```
+
+Verify the R2 bucket name in `wrangler.toml` matches your actual bucket
+(Cloudflare dashboard → R2 → buckets). Update `bucket_name` if needed.
+
+Deploy:
+
+```bash
+wrangler deploy
+```
+
+This publishes the Worker and installs the route `data.isamples.org/*`.
+
+> ⚠️ If another Worker is already bound to `data.isamples.org/*` (e.g. a
+> legacy proxy from the original setup), `wrangler deploy` will **replace**
+> it. Check `wrangler deployments list` or the Cloudflare dashboard
+> (Workers → Routes) before deploying if you want to be cautious.
+
+## Verifying
+
+After deploy:
+
+```bash
+curl -sI https://data.isamples.org/isamples_202601_h3_summary_res4.parquet \
+  | grep -iE 'cache-control|cf-cache-status|etag'
+```
+
+You should see:
+
+```
+cache-control: public, max-age=31536000, immutable
+etag: "..."
+```
+
+First request after deploy will show `cf-cache-status: MISS`; subsequent
+requests should show `HIT` (edge cache warmed). Browser refreshes on the
+Interactive Explorer (`?perf=1`) should drop phase 1 res4 duration toward
+zero on warm cache.
+
+## Local dev
+
+```bash
+wrangler dev
+```
+
+Starts a local server on `http://localhost:8787/` that proxies the live R2
+bucket. Useful for testing header logic without touching production.
+
+## Future extensions
+
+- Path-based routing (e.g. `/parquet/...`, `/record/<uuid>`) per issue #81
+- Per-object cache hints via R2 custom metadata
+- Index listing at `/` (currently just a plain-text stub)

--- a/workers/data-isamples-org/src/index.js
+++ b/workers/data-isamples-org/src/index.js
@@ -1,0 +1,134 @@
+/**
+ * Cloudflare Worker: data.isamples.org
+ *
+ * Proxies the iSamples R2 bucket and adds cache-control headers so the
+ * Cloudflare edge and the browser can cache immutable parquet versions
+ * aggressively.
+ *
+ * Strategy:
+ *   - Filename-versioned parquets (isamples_YYYYMM_*.parquet) are immutable
+ *     by naming convention → cache one year + immutable.
+ *   - Anything else falls back to a short TTL.
+ *
+ * Uses the R2 bucket binding (env.BUCKET) rather than fetching the r2.dev
+ * public URL — fewer hops, lower latency, no need to expose the bucket
+ * publicly.
+ *
+ * Range requests are supported so DuckDB-WASM's HTTP range fetches keep
+ * working.
+ */
+
+const IMMUTABLE_PATTERN = /^isamples_\d{6}_.*\.parquet$/;
+const IMMUTABLE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+const FALLBACK_MAX_AGE = 300; // 5 minutes
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+  'Access-Control-Allow-Headers': 'Range',
+  'Access-Control-Expose-Headers': 'Content-Length, Content-Range, Accept-Ranges, ETag',
+};
+
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', { status: 405, headers: CORS_HEADERS });
+    }
+
+    const url = new URL(request.url);
+    const key = decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+
+    if (!key) {
+      // Simple root response — could be replaced with an index listing later.
+      return new Response('data.isamples.org — R2 bucket proxy\n', {
+        status: 200,
+        headers: { 'content-type': 'text/plain; charset=utf-8', ...CORS_HEADERS },
+      });
+    }
+
+    // Parse Range header if present. R2's get() accepts { offset, length } or
+    // { suffix }, mirroring HTTP Range semantics.
+    const rangeHeader = request.headers.get('range');
+    const range = rangeHeader ? parseRange(rangeHeader) : undefined;
+
+    const getOptions = range ? { range } : {};
+    const object = request.method === 'HEAD'
+      ? await env.BUCKET.head(key)
+      : await env.BUCKET.get(key, getOptions);
+
+    if (!object) {
+      return new Response('Not found', { status: 404, headers: CORS_HEADERS });
+    }
+
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set('ETag', object.httpEtag);
+    headers.set('Accept-Ranges', 'bytes');
+
+    for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+
+    // Cache-Control: this is the optimization.
+    if (IMMUTABLE_PATTERN.test(key)) {
+      headers.set('Cache-Control', `public, max-age=${IMMUTABLE_MAX_AGE}, immutable`);
+    } else {
+      headers.set('Cache-Control', `public, max-age=${FALLBACK_MAX_AGE}`);
+    }
+
+    if (request.method === 'HEAD') {
+      headers.set('Content-Length', String(object.size));
+      return new Response(null, { status: 200, headers });
+    }
+
+    // Range response: 206 + Content-Range. R2 populates object.range when a
+    // range was requested, but for safety compute the Content-Range ourselves.
+    if (range) {
+      const total = object.size !== undefined ? object.size : null;
+      // object.get with range returns only the sliced body + partial size info.
+      // We need the full object size for the Content-Range header; fetch via
+      // head() once per cold request.
+      let fullSize = total;
+      if (fullSize == null || typeof fullSize !== 'number') {
+        const head = await env.BUCKET.head(key);
+        fullSize = head ? head.size : null;
+      }
+      const start = range.offset ?? 0;
+      const length = range.length ?? (fullSize != null ? fullSize - start : undefined);
+      const end = length != null ? start + length - 1 : (fullSize != null ? fullSize - 1 : 0);
+      if (fullSize != null) {
+        headers.set('Content-Range', `bytes ${start}-${end}/${fullSize}`);
+        headers.set('Content-Length', String(end - start + 1));
+      }
+      return new Response(object.body, { status: 206, headers });
+    }
+
+    return new Response(object.body, { status: 200, headers });
+  },
+};
+
+/**
+ * Parse an HTTP Range header into the { offset, length } shape R2 expects.
+ * Supports `bytes=START-END` and `bytes=-SUFFIX`. Returns undefined for
+ * anything we can't parse so the caller falls back to a full-object fetch.
+ */
+function parseRange(header) {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return undefined;
+  const [, startStr, endStr] = match;
+  if (startStr === '' && endStr === '') return undefined;
+  if (startStr === '') {
+    // Suffix: last N bytes
+    const suffix = Number(endStr);
+    if (!Number.isFinite(suffix) || suffix <= 0) return undefined;
+    return { suffix };
+  }
+  const offset = Number(startStr);
+  if (!Number.isFinite(offset) || offset < 0) return undefined;
+  if (endStr === '') return { offset };
+  const end = Number(endStr);
+  if (!Number.isFinite(end) || end < offset) return undefined;
+  return { offset, length: end - offset + 1 };
+}

--- a/workers/data-isamples-org/wrangler.toml
+++ b/workers/data-isamples-org/wrangler.toml
@@ -10,10 +10,9 @@ compatibility_date = "2026-04-01"
 
 # Bind the R2 bucket that holds the iSamples parquet files.
 # The binding name (BUCKET) matches env.BUCKET in src/index.js.
-# Replace `isamples-data` with the actual R2 bucket name if different.
 [[r2_buckets]]
 binding = "BUCKET"
-bucket_name = "isamples-data"
+bucket_name = "isamples-ry"
 
 # Route: everything under data.isamples.org goes through this Worker.
 # Zone is inferred from isamples.org being in the same Cloudflare account.

--- a/workers/data-isamples-org/wrangler.toml
+++ b/workers/data-isamples-org/wrangler.toml
@@ -1,0 +1,26 @@
+# Cloudflare Worker: data.isamples.org
+#
+# Proxies the iSamples R2 bucket and adds Cache-Control so edge + browser
+# caches can treat versioned parquets as immutable. See README.md for deploy
+# instructions.
+
+name = "data-isamples-org"
+main = "src/index.js"
+compatibility_date = "2026-04-01"
+
+# Bind the R2 bucket that holds the iSamples parquet files.
+# The binding name (BUCKET) matches env.BUCKET in src/index.js.
+# Replace `isamples-data` with the actual R2 bucket name if different.
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "isamples-data"
+
+# Route: everything under data.isamples.org goes through this Worker.
+# Zone is inferred from isamples.org being in the same Cloudflare account.
+routes = [
+  { pattern = "data.isamples.org/*", zone_name = "isamples.org" },
+]
+
+# Observability: enable Worker logs in the Cloudflare dashboard.
+[observability]
+enabled = true


### PR DESCRIPTION
## Why

Audit of \`data.isamples.org\` response headers (follow-up to PR #119 perf timing work) found no \`Cache-Control\`, no \`cf-cache-status\`, no \`expires\` — Cloudflare's edge is **not** caching the parquet files, and browsers fall back to heuristic caching (often: re-fetch on every visit).

Filename-versioned parquets like \`isamples_202601_wide.parquet\` are immutable by naming convention — the URL content never changes. They should have:

\`\`\`
Cache-Control: public, max-age=31536000, immutable
\`\`\`

## What

Adds \`workers/data-isamples-org/\` (colocated with the site that uses it) containing:

- \`src/index.js\` — Worker code: R2 bucket binding, range requests, CORS, cache-control rewrite
- \`wrangler.toml\` — deploy config, route \`data.isamples.org/*\`
- \`README.md\` — what it does, how to deploy, how to verify

Quarto does not render the \`workers/\` tree; files are GitHub-rendered markdown.

## ⚠️ Not deployed automatically

This PR does not deploy the Worker. Once merged, deploy it yourself:

\`\`\`bash
cd workers/data-isamples-org
wrangler login         # one-time
wrangler deploy
\`\`\`

If a different Worker currently owns the \`data.isamples.org/*\` route, \`wrangler deploy\` **will replace it.** Run \`wrangler deployments list\` or check the Cloudflare dashboard (Workers → Routes) before deploying if you want to inspect what's there first.

The \`bucket_name\` in \`wrangler.toml\` is a guess — verify it matches your actual R2 bucket name in the Cloudflare dashboard before deploying.

## Expected impact

Stacks on PR #119 preload hints:

| Scenario | Today | After deploy |
|---|---|---|
| Cold visit (first-ever user) | R2 origin pull | R2 origin pull (same) |
| Cold visit (edge warmed by prior user) | R2 origin pull | Edge hit — 10-100 ms |
| Refresh | Re-fetch whole file | Browser cache — 0 ms |
| Zoom in/out, revisit res4 | Re-fetch | Browser cache — 0 ms |

## Test plan

- [ ] Review Worker code and wrangler.toml config
- [ ] Verify R2 bucket name matches your actual bucket
- [ ] \`wrangler deploy\`
- [ ] \`curl -sI https://data.isamples.org/isamples_202601_h3_summary_res4.parquet | grep -iE 'cache-control|cf-cache-status'\` shows the new header
- [ ] Visit Interactive Explorer with \`?perf=1\`, refresh, confirm phase 1 res4 drops toward zero on warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)