### PR TITLE
Correct Worker name to match deployed: isamples-data

### DIFF
--- a/workers/data-isamples-org/README.md
+++ b/workers/data-isamples-org/README.md
@@ -55,10 +55,12 @@ wrangler deploy
 
 This publishes the Worker and installs the route `data.isamples.org/*`.
 
-> ⚠️ If another Worker is already bound to `data.isamples.org/*` (e.g. a
-> legacy proxy from the original setup), `wrangler deploy` will **replace**
-> it. Check `wrangler deployments list` or the Cloudflare dashboard
-> (Workers → Routes) before deploying if you want to be cautious.
+> The Worker is named `isamples-data` in `wrangler.toml` to match the
+> pre-existing Worker that owned `data.isamples.org/*` before this repo
+> existed. `wrangler deploy` atomically replaces the existing Worker at
+> that name. If you rename, also unassign the old Worker from the route
+> first (Cloudflare dashboard → Workers → Routes) or the deploy will
+> fail with "already assigned to another worker."
 
 ## Verifying
 

--- a/workers/data-isamples-org/wrangler.toml
+++ b/workers/data-isamples-org/wrangler.toml
@@ -4,18 +4,16 @@
 # caches can treat versioned parquets as immutable. See README.md for deploy
 # instructions.
 
-name = "data-isamples-org"
+name = "isamples-data"
 main = "src/index.js"
 compatibility_date = "2026-04-01"
 
-# Bind the R2 bucket that holds the iSamples parquet files.
-# The binding name (BUCKET) matches env.BUCKET in src/index.js.
-[[r2_buckets]]
-binding = "BUCKET"
-bucket_name = "isamples-ry"
+# Raymond.yee@gmail.com's account — owner of the isamples.org zone and the
+# isamples-ry R2 bucket.
+account_id = "75e8a095c424e5a4e18fd6f5e6145064"
 
 # Route: everything under data.isamples.org goes through this Worker.
-# Zone is inferred from isamples.org being in the same Cloudflare account.
+# (Declared before [[r2_buckets]] so TOML doesn't scope it to that table.)
 routes = [
   { pattern = "data.isamples.org/*", zone_name = "isamples.org" },
 ]
@@ -23,3 +21,9 @@ routes = [
 # Observability: enable Worker logs in the Cloudflare dashboard.
 [observability]
 enabled = true
+
+# Bind the R2 bucket that holds the iSamples parquet files.
+# The binding name (BUCKET) matches env.BUCKET in src/index.js.
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "isamples-ry"


### PR DESCRIPTION
Follow-up to #120 — discovered during deploy that the existing Worker is named `isamples-data`, not our invented `data-isamples-org`. Renamed so `wrangler deploy` atomically replaces the existing Worker. Also fixes TOML ordering (routes was being scoped to r2_buckets table) and adds the explicit account_id.

**Verified live**: `curl -sI https://data.isamples.org/isamples_202601_h3_summary_res4.parquet` now returns `cache-control: public, max-age=31536000, immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)