### PR TITLE
Port preconnect + preload pattern to Explorer and Deep-Dive

### DIFF
--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -6,6 +6,11 @@ format:
     code-fold: true
     toc: true
     toc-depth: 3
+    include-in-header:
+      text: |
+        <link rel="preconnect" href="https://data.isamples.org" crossorigin>
+        <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/isamples_202601_facet_summaries.parquet">
+        <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/isamples_202601_facet_cross_filter.parquet">
 ---
 
 Search and explore **6.7 million physical samples** from scientific collections worldwide.

--- a/tutorials/zenodo_isamples_analysis.qmd
+++ b/tutorials/zenodo_isamples_analysis.qmd
@@ -10,6 +10,10 @@ format:
     toc: true
     toc-depth: 3
     theme: cosmo
+    include-in-header:
+      text: |
+        <link rel="preconnect" href="https://data.isamples.org" crossorigin>
+        <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/isamples_202601_facet_summaries.parquet">
 ---
 
 # Introduction


### PR DESCRIPTION
Port-out discipline — once PR #119's preload pattern proved on progressive_globe, apply it to the other two tutorial pages.

- **isamples_explorer**: preconnect + preload facet_summaries (2 KB) + facet_cross_filter (6 KB). The 280 MB wide parquet is on-demand via range requests, not preloaded.
- **zenodo_isamples_analysis**: preconnect + preload facet_summaries (2 KB). The 292 MB wide_h3 primary dataset is not preloaded for the same reason.

All three tutorials now benefit from the `data.isamples.org` Worker's immutable cache-control (deployed 2026-04-17) — these edge hits are durable across visits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)