### PR TITLE
Disable TOC sidebar on Interactive Explorer (fixes #127)

### DIFF
--- a/tutorials/progressive_globe.qmd
+++ b/tutorials/progressive_globe.qmd
@@ -3,6 +3,10 @@ title: "Interactive Explorer"
 subtitle: "Search and explore 6.7 million material samples"
 categories: [parquet, spatial, h3, performance, isamples]
 sidebar: false
+# No TOC: this page is an app, not an article. The right-hand TOC sidebar
+# (#quarto-margin-sidebar) was overlapping .side-panel and silently
+# intercepting clicks on the Source filter checkboxes — see issue #127.
+toc: false
 format:
   html:
     include-in-header:


### PR DESCRIPTION
Fixes #127. The `#quarto-margin-sidebar` was overlapping the filter panel and intercepting clicks on the Source filter checkboxes. Setting `toc: false` removes it. Full diagnosis in the issue.

Follow-up: audit `isamples_explorer.qmd` and `zenodo_isamples_analysis.qmd` for the same overlap — both still have `toc: true` and side-panel layouts.