### PR TITLE
docs: clarify vocabulary page generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,23 @@ Preview the site:
 quarto preview
 ```
 
-Vocabulary documentation is generated from the vocabulary source ttl files using a python script, `scripts/vocab2md.py` and a convenience shell script wrapper, `scripts/generate_vocab_docs.sh`. To regenerate the vocabulary documentation, first `cd` to the root folder of the documentation, then:
+### Vocabulary page generation
+
+The vocabulary pages under `models/generated/vocabularies/` (e.g. [material_sample_object_type.html](https://isamples.org/models/generated/vocabularies/material_sample_object_type.html)) are produced by a deterministic two-stage pipeline:
+
+1. **TTL → markdown.** `scripts/generate_vocab_docs.sh` fetches each `.ttl` from [isamplesorg/vocabularies](https://github.com/isamplesorg/vocabularies) (and the extension repos) and runs `vocab markdown <ttl-url>` — the `vocab` CLI from [isamplesorg/vocab_tools](https://github.com/isamplesorg/vocab_tools), installed via `pipx` in CI. The output is written as a `.qmd` (core vocabularies) or `.md` (extensions) into `models/generated/`.
+2. **Markdown → HTML.** `quarto render` walks the site and applies the theme, navigation, and sidebar defined in `_quarto.yml` to every page, including the generated vocabulary markdown. The site chrome comes from Quarto; the vocabulary content is untouched.
+
+Both stages run in the [`quarto-pages.yml`](.github/workflows/quarto-pages.yml) GitHub Action on every deploy.
+
+To regenerate locally, from the repo root:
 
 ```
 scripts/generate_vocab_docs.sh
+quarto render
 ```
 
-The generated docs are placed under `models/generated/vocabularies`
+**Note on `scripts/vocab2md.py`.** An earlier version of this pipeline invoked `vocab2md.py` directly. PR [#48](https://github.com/isamplesorg/isamplesorg.github.io/pull/48) switched to the `vocab markdown` CLI entry point — same tool, same transform. The `vocab2md.py` file is retained for reference but is no longer part of the build.
 
 After editing, push the sources to GitHub. The rendered pages are generated using the `Render using Quarto and push to GH-pages` GitHub action that is currently manually triggered.
 


### PR DESCRIPTION
## Summary

Rewrites the Development section of the README to accurately describe the two-stage vocabulary page build:

1. **TTL → markdown** via the `vocab` CLI from [isamplesorg/vocab_tools](https://github.com/isamplesorg/vocab_tools) (installed via pipx in CI), driven by `scripts/generate_vocab_docs.sh`.
2. **markdown → HTML** via `quarto render` applying `_quarto.yml`'s theme, navigation, and sidebar.

Also notes that `scripts/vocab2md.py` is no longer part of the build — PR #48 switched to the `vocab markdown` CLI entry point (same tool, same transform). The existing README paragraph still pointed at `vocab2md.py`, which caused confusion about which code produces the rendered vocabulary pages.

No functional changes; documentation only.

## Test plan

- [ ] Read the rendered README on GitHub and verify links resolve
- [ ] Confirm the described pipeline matches `.github/workflows/quarto-pages.yml` and `scripts/generate_vocab_docs.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)