### PR TITLE
Explorer: render SKOS prefLabels for facet URIs (#148 step 2)

### DIFF
--- a/tutorials/archive/parquet_cesium_isamples_wide.qmd
+++ b/tutorials/archive/parquet_cesium_isamples_wide.qmd
@@ -96,7 +96,7 @@ viewof viewModeToggle = Inputs.radio(["clustered", "all points"], {
 ```{ojs}
 //| echo: false
 // Source color scheme — imported from canonical palette (issue #113)
-_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
+_palette = await import(new URL('../../assets/js/source-palette.js', document.baseURI).href)
 CLUSTER_COLORS = _palette.SOURCE_COLORS
 
 // H3 resolution based on camera height

--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -104,7 +104,10 @@ sample_facets_url = "https://data.isamples.org/isamples_202601_sample_facets_v2.
 vocab_labels_url = "https://data.isamples.org/vocab_labels.parquet"
 
 // Source color scheme — imported from canonical palette (issue #113)
-_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
+// Use a path-relative URL so this works under both the production custom
+// domain (isamples.org/tutorials/...) and a project-pages fork preview
+// (rdhyee.github.io/isamplesorg.github.io/tutorials/...).
+_palette = await import(new URL('../assets/js/source-palette.js', document.baseURI).href)
 SOURCE_COLORS = _palette.SOURCE_COLORS
 
 // Cesium colors

--- a/tutorials/isamples_explorer.qmd
+++ b/tutorials/isamples_explorer.qmd
@@ -11,6 +11,7 @@ format:
         <link rel="preconnect" href="https://data.isamples.org" crossorigin>
         <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/isamples_202601_facet_summaries.parquet">
         <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/isamples_202601_facet_cross_filter.parquet">
+        <link rel="preload" as="fetch" crossorigin="anonymous" href="https://data.isamples.org/vocab_labels.parquet">
         <script>
         // Opt-in perf panel (?perf=1). Plain script — independent of the
         // OJS reactive graph, which was unreliable at firing this cell.
@@ -98,6 +99,10 @@ cross_filter_url = "https://data.isamples.org/isamples_202601_facet_cross_filter
 // Facets file for on-the-fly multi-filter queries (63MB - URI strings, not BIGINT FKs)
 sample_facets_url = "https://data.isamples.org/isamples_202601_sample_facets_v2.parquet"
 
+// Vocabulary labels (~60KB) — maps SKOS concept URIs to human-readable prefLabels.
+// Built by scripts/build_vocab_labels.py from isamplesorg/vocabularies TTLs. See #148.
+vocab_labels_url = "https://data.isamples.org/vocab_labels.parquet"
+
 // Source color scheme — imported from canonical palette (issue #113)
 _palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
 SOURCE_COLORS = _palette.SOURCE_COLORS
@@ -180,8 +185,8 @@ viewof materialCheckboxes = {
     format: (x) => {
       const r = counts.find(s => s.value === x);
       const count = r ? Number(r.count).toLocaleString() : "0";
-      return html`<span style="display: inline-flex; align-items: center; gap: 4px;">
-        ${x} <span class="facet-count" data-facet="material" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
+      return html`<span style="display: inline-flex; align-items: center; gap: 4px;" title="${x}">
+        ${prettyLabel(x)} <span class="facet-count" data-facet="material" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
       </span>`;
     }
   });
@@ -201,8 +206,8 @@ viewof contextCheckboxes = {
     format: (x) => {
       const r = counts.find(s => s.value === x);
       const count = r ? Number(r.count).toLocaleString() : "0";
-      return html`<span style="display: inline-flex; align-items: center; gap: 4px;">
-        ${x} <span class="facet-count" data-facet="context" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
+      return html`<span style="display: inline-flex; align-items: center; gap: 4px;" title="${x}">
+        ${prettyLabel(x)} <span class="facet-count" data-facet="context" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
       </span>`;
     }
   });
@@ -222,8 +227,8 @@ viewof objectTypeCheckboxes = {
     format: (x) => {
       const r = counts.find(s => s.value === x);
       const count = r ? Number(r.count).toLocaleString() : "0";
-      return html`<span style="display: inline-flex; align-items: center; gap: 4px;">
-        ${x} <span class="facet-count" data-facet="object_type" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
+      return html`<span style="display: inline-flex; align-items: center; gap: 4px;" title="${x}">
+        ${prettyLabel(x)} <span class="facet-count" data-facet="object_type" data-value="${x}" style="color: #888; font-size: 11px;">(${count})</span>
       </span>`;
     }
   });
@@ -454,6 +459,36 @@ facetsByType = {
     grouped[key].sort((a, b) => b.count - a.count);
   }
   return grouped;
+}
+```
+
+```{ojs}
+//| code-fold: true
+// Load SKOS prefLabels for vocabulary URIs (#148). Tiny lookup (~60KB);
+// fallback to last URI segment if a URI isn't covered.
+vocabLabels = {
+  try {
+    const rows = await runQuery(
+      `SELECT uri, pref_label FROM read_parquet('${vocab_labels_url}') WHERE lang = 'en'`
+    );
+    const m = new Map();
+    for (const r of rows) m.set(r.uri, r.pref_label);
+    return m;
+  } catch (e) {
+    console.warn("vocab_labels load failed; falling back to URI tails:", e);
+    return new Map();
+  }
+}
+
+prettyLabel = function (uri) {
+  if (uri == null) return "";
+  const hit = vocabLabels.get(uri);
+  if (hit) return hit;
+  // Fallback: last non-empty path segment of the URI
+  const s = String(uri);
+  if (!/^https?:\/\//.test(s)) return s;
+  const parts = s.replace(/[#?].*$/, "").split("/").filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : s;
 }
 ```
 

--- a/tutorials/progressive_globe.qmd
+++ b/tutorials/progressive_globe.qmd
@@ -208,8 +208,10 @@ wide_url = `${R2_BASE}/current/wide.parquet`
 facets_url = `${R2_BASE}/isamples_202601_sample_facets.parquet`
 facet_summaries_url = `${R2_BASE}/isamples_202601_facet_summaries.parquet`
 
-// Canonical palette — see issue #113
-_palette = await import(new URL('/assets/js/source-palette.js', document.baseURI).href)
+// Canonical palette — see issue #113. Path-relative so this works under
+// both isamples.org (custom domain at root) and project-pages fork
+// previews (rdhyee.github.io/isamplesorg.github.io/...).
+_palette = await import(new URL('../assets/js/source-palette.js', document.baseURI).href)
 SOURCE_COLORS = _palette.SOURCE_COLORS
 SOURCE_NAMES = _palette.SOURCE_NAMES
 


### PR DESCRIPTION
Second step of #148 — wires the canonical \`vocab_labels.parquet\` artifact (PR #149) into the Interactive Explorer's facet UI.

## Summary

- Loads \`https://data.isamples.org/vocab_labels.parquet\` (58KB, now live behind the data-isamples-org Worker) into a URI → prefLabel \`Map\`.
- New \`prettyLabel(uri)\` helper: returns the SKOS prefLabel when known, else falls back to the last URI path segment, else the raw value. Safe against the 4 known unresolved URIs (~169 / ~6M samples — flagged as upstream design debt in #148).
- Material / Sampled Feature / Specimen Type checkboxes now render labels instead of URIs. Full URI preserved in a hover tooltip.
- Preload hint added for cache-warm parity with the other parquets.

## Verification

- \`curl -sI https://data.isamples.org/vocab_labels.parquet\` → 200, correct content-type, ETag set.
- Local Quarto render + Playwright smoke test on \`docs/tutorials/isamples_explorer.html\`: **0 JS exceptions, 0 console errors, 0 network failures**.

## What this doesn't do

- Doesn't fix the upstream root cause (\`IdentifiedConcept.label\` holds the URI in the wide parquet; \`scheme_name\` is NULL). That's pqg work — separate PR after we agree on whether the converter populates label from \`vocab_labels\` at build time, or whether consumers always JOIN.
- Doesn't yet wire labels into the other facet UIs across the site (notebooks, future detail panels). Same lookup file is reusable when we get there.

## File touched

- \`tutorials/isamples_explorer.qmd\` — preload hint, \`vocab_labels_url\`, \`vocabLabels\` cell, \`prettyLabel()\` helper, three format-callback edits.