### PR TITLE
explorer: interim recall fix — search description (#168 Direction A, knowingly slower)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -239,12 +239,12 @@ Circle size = log(sample count). Color = dominant data source.
 
 <!-- Static layout: globe + side panel. Updated via DOM, not OJS reactivity. -->
 <div class="search-bar">
-<input type="text" id="sampleSearch" placeholder="Search samples — multiple words narrow results (e.g., basalt California)" />
+<input type="text" id="sampleSearch" placeholder="Search samples — multiple words narrow results (e.g., pottery Cyprus)" />
 <button id="searchBtn">Search</button>
 </div>
 <div class="search-help" style="font-size: 11px; color: #888; padding: 2px 0 6px 0; line-height: 1.3;">
-Searches sample labels and place names only — descriptions are not yet indexed.
-<a href="https://github.com/isamplesorg/isamplesorg.github.io/issues/169" target="_blank" rel="noopener noreferrer" style="color: #888; text-decoration: underline;">Tracking issue: substrate FTS will lift this</a>.
+Searches labels, descriptions, and place names. <strong>First search can take 10-15 seconds</strong> while data loads; subsequent searches are faster.
+<a href="https://github.com/isamplesorg/isamplesorg.github.io/issues/169" target="_blank" rel="noopener noreferrer" style="color: #888; text-decoration: underline;">Tracking issue: faster substrate FTS in progress</a>.
 </div>
 <div id="searchResults" class="search-results"></div>
 
@@ -1847,20 +1847,51 @@ zoomWatcher = {
         let errorMessage = null;
 
         try {
-            const searchWhere = textSearchWhere(terms, ['label', 'CAST(place_name AS VARCHAR)']);
+            // INTERIM RECALL FIX (#168 Direction A) — knowingly accepts the
+            // latency regression in exchange for fixing false-zero results.
+            //
+            // Background: the previous query searched samples_map_lite over
+            // label + place_name only; samples_map_lite does not carry
+            // description, so queries like `pottery Cyprus` returned zero
+            // even when ~7,124 samples actually match (Cyprus appears only
+            // in description). This is a *broken* user experience even
+            // though it's fast.
+            //
+            // This is NOT the FTS solution. The proper substrate work in
+            // #169-#172 builds a sample-centric document projection with
+            // hash-partitioned BM25 indexes that fixes both recall AND
+            // latency. This code path goes away when #171 lands.
+            //
+            // CTE-then-keyed-join shape (NOT a naive LEFT JOIN). Native
+            // DuckDB benchmark: naive 4.2 s vs CTE 0.5 s for `pottery`.
+            // The browser DuckDB-WASM penalty makes the difference even
+            // more pronounced; the naive form times out on `pottery` cold.
+            const searchWhere = textSearchWhere(terms, [
+                'label',
+                'description',
+                'CAST(place_name AS VARCHAR)',
+            ]);
             const score = textSearchScore(terms, [
-                { col: 'label', weight: 3 },
+                { col: 'label',                       weight: 3 },
+                { col: 'description',                 weight: 1 },
                 { col: 'CAST(place_name AS VARCHAR)', weight: 2 },
             ]);
             const results = await db.query(`
-                SELECT pid, label, source, latitude, longitude, place_name,
-                       (${score}) AS relevance_score
-                FROM read_parquet('${lite_url}')
-                WHERE ${searchWhere}
-                ${sourceFilterSQL('source')}
-                ${facetFilterSQL()}
-                ORDER BY relevance_score DESC, label
-                LIMIT 50
+                WITH matches AS (
+                    SELECT pid, label, source, place_name,
+                           (${score}) AS relevance_score
+                    FROM read_parquet('${facets_url}')
+                    WHERE ${searchWhere}
+                    ${sourceFilterSQL('source')}
+                    ${facetFilterSQL()}
+                    ORDER BY relevance_score DESC
+                    LIMIT 50
+                )
+                SELECT m.pid, m.label, m.source, l.latitude, l.longitude,
+                       m.place_name, m.relevance_score
+                FROM matches m
+                LEFT JOIN read_parquet('${lite_url}') l USING (pid)
+                ORDER BY m.relevance_score DESC, m.label
             `);
             resultsCount = results.length;
             if (results.length === 0) {

--- a/query-spec.qmd
+++ b/query-spec.qmd
@@ -222,13 +222,14 @@ Solr `searchText` copy-field target, canonical list):
 
 Substrates that can't index all 15 fields MUST document which subset
 they cover and surface the limitation in UI. (As of 2026-05-08, the
-current web Explorer covers `label` + `place_name` only against
-`samples_map_lite.parquet`, which does not carry `description` —
-a known gap that broke `pottery Cyprus` and similar queries in the
-#167 baseline. The substrate work in
+current web Explorer covers `label` + `description` + `place_name`
+against `sample_facets_v2.parquet` (joined to `samples_map_lite.parquet`
+for display coordinates) — a deliberate **interim recall fix** that
+trades latency for honest coverage; cold first searches take ~10-15 s
+while DuckDB-WASM warms up. The proper substrate work in
 [#169](https://github.com/isamplesorg/isamplesorg.github.io/issues/169)
-will lift this by adding `description` *and* dereferenced concept
-labels in the v1 minimum field set.)
+adds dereferenced concept labels and partitioned BM25 indexes that
+fix both the field gap and the latency regression.)
 
 Multi-term queries default to **AND** with relevance ranking where the
 substrate supports it (Solr, DuckDB FTS). See PR #95 for web-side FTS
@@ -293,7 +294,7 @@ missing values gracefully.
 |---|---|
 | `source IN (…)` | `n IN (…)` on wide / narrow (column is `n` per PQG); `source IN (…)` on lite / sample_facets_v2 (alias exposed) |
 | `material IN (…)` | `pid IN (SELECT pid FROM sample_facets WHERE material IN (…))` |
-| `text MATCHES "q"` | `(label ILIKE '%q%' OR description ILIKE '%q%' OR place_name ILIKE '%q%')` — currently a subset of §3.2 |
+| `text MATCHES "q"` | `(label ILIKE '%q%' OR description ILIKE '%q%' OR CAST(place_name AS VARCHAR) ILIKE '%q%')` over `sample_facets_v2.parquet`, joined back to `samples_map_lite.parquet` for display coordinates — currently a subset of §3.2; substrate-backed FTS in [#169](https://github.com/isamplesorg/isamplesorg.github.io/issues/169) extends to dereferenced concept labels in v1 |
 | `bbox WITHIN (…)` | `latitude BETWEEN … AND … AND longitude BETWEEN … AND …` |
 | `h3 AT RES 6 IN (…)` | `h3_res6 IN (…)` on `wide_h3`; OR `h3_cell IN (…) AND resolution = 6` on `h3_summary_res6` (see §2.4 note) |
 | `time BETWEEN …` | `TRY_CAST(result_time AS TIMESTAMP) BETWEEN t1 AND t2` — `result_time` ships as VARCHAR in `lite`, `wide`, and `narrow` |


### PR DESCRIPTION
## Summary — interim recall fix, NOT the future FTS backend

\`doSearch()\` swapped from \`samples_map_lite.parquet\` to \`sample_facets_v2.parquet\` so live search now covers \`label + description + place_name\` instead of \`label + place_name\`. **This trades latency for honest recall**, knowingly violating the latency thresholds locked in #168.

The previous live search returned **zero** results for \`pottery Cyprus\` even though ~7,124 samples actually match (Cyprus appears only in description). The #168 honesty-fix landed in #176 documented this gap; this PR closes it functionally as an *interim* state while the proper substrate work in #169-#172 builds the real FTS that fixes both recall and latency.

## Why this is shipping despite the threshold failure

- #168 locked: cold \`pottery\` ≤ 5 s, multi-term ≤ 6 s.
- #167 baseline measured the swap at 12 s and 14.8 s respectively.
- **Strictly per the threshold rule, Direction B (the doc fix in #176) was the answer.** That's what merged.
- But the threshold was set when we expected the swap to be roughly latency-neutral. It isn't. And "fast and broken" (current behavior on \`pottery Cyprus\`: 5 s, returns 0 results) is worse UX than "slow and useful" (this PR: 15 s, returns 50 results).
- A search bar that tells you \`pottery Cyprus\` is a good example query, then returns nothing for it, is broken. We made the placeholder example honest first; this PR makes the underlying behavior honest.

This is the kind of decision the threshold rule was a *guess* about, not an answer to. The data flipped the answer.

## What this is NOT

- **Not the FTS solution.** #169-#172 builds the real substrate: sample-centric document projection (label + description + place_name + dereferenced concept labels), hash-partitioned BM25 indexes, sub-second cold search, sub-500-ms warm. This PR's interim search goes away the day #171 lands.
- **Not a reversal of the substrate decision.** The state contract (PR #166) and search-index contract (#169 / PR #175) stand. Track 6 (hosted-search) remains a contingency.
- **Not a precedent for relaxing locked thresholds.** Future locked thresholds remain locked unless similarly contested by data.

## What changes

- \`explorer.qmd\` \`doSearch()\` SQL: CTE-then-keyed-join over \`sample_facets_v2\` (filter to top-50 first, then keyed JOIN to \`samples_map_lite\` for coordinates). Native DuckDB benchmark showed the naive LEFT JOIN form is 8× slower (4.2 s vs 0.5 s for \`pottery\`) and times out in browser; the CTE form is the only shippable shape.
- \`explorer.qmd\` search-help line: updated to "Searches labels, descriptions, and place names. **First search can take 10-15 seconds** while data loads; subsequent searches are faster." Forward-link to #169.
- \`explorer.qmd\` placeholder example: \`pottery Cyprus\` (a query that *now works*).
- \`query-spec.qmd\`: §3.2 wording reflects the interim state with explicit "interim" framing; §5.1 binding describes the new query shape.

## Cold-search caveat

The new \`.search-help\` UI line warns users that the **first cold search can take 10-15 seconds**. This is honest. The substrate work fixes it. Users who hit that latency see a "Searching..." indicator (existing behavior) plus the new explanatory line.

A future PR could add an explicit progress spinner or shimmer; out of scope here.

## What this unblocks

- \`pottery Cyprus\`, \`Çatalhöyük\` (in description), \`100%\` (in description) — all flip 0 → 50 results.
- The substrate work (#170, #171, #172) is **not** blocked by this; the interim and the substrate are independent code paths and the substrate replaces this when ready.

## Test plan

- [ ] Open Explorer; verify \`pottery Cyprus\` now returns 50 results in ~10-15 s cold, ~3-5 s warm.
- [ ] Verify \`Çatalhöyük\` returns 50 results.
- [ ] Verify source filter still works (\`pottery\` × OPENCONTEXT only).
- [ ] Verify a result with no lat/lng still renders in side panel without crashing (LEFT JOIN can produce null coords for samples not in samples_map_lite).
- [ ] Verify the \`?perf=1\` panel shows the new search timings per the #173 instrumentation.
- [ ] Verify the search-help line is visible and reads honestly.

Closes #168 (functionally — the recall gap that PR #176 documented). Refs #165, #167, #169-#172, PR #166, PR #173, PR #175, PR #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)