### PR TITLE
explorer: native Cesium toolbar + prominent share button + a11y halos

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -88,11 +88,29 @@ format:
     .detail-link { color: #1565c0; text-decoration: none; font-size: 12px; }
     .detail-link:hover { text-decoration: underline; }
     .share-btn {
-        background: #1565c0; color: white; border: none; padding: 4px 12px;
-        border-radius: 4px; font-size: 12px; cursor: pointer;
+        background: #1565c0; color: white; border: none;
+        padding: 10px 16px; border-radius: 6px;
+        font-size: 14px; font-weight: 500; cursor: pointer;
+        width: 100%;
     }
     .share-btn:hover { background: #0d47a1; }
-    .share-toast { font-size: 12px; color: #2e7d32; opacity: 0; transition: opacity 0.3s; }
+    .share-toast { display: block; font-size: 12px; color: #2e7d32; opacity: 0; transition: opacity 0.3s; margin-top: 4px; text-align: center; }
+    /* Cesium toolbar — relocate to top-left of globe (Hana mockup, #178) */
+    .cesium-viewer-toolbar {
+        top: 5px;
+        left: 5px;
+        right: auto !important;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        align-items: flex-start;
+    }
+    .cesium-viewer-toolbar > * { margin-left: 0 !important; }
+    /* Open baseLayerPicker dropdown to the right since we're left-anchored */
+    .cesium-baseLayerPicker-dropDown {
+        left: 36px;
+        right: auto;
+    }
     .search-bar { display: flex; gap: 6px; margin-bottom: 6px; }
     .search-bar input {
         flex: 1; padding: 8px 12px; border: 1px solid #ccc; border-radius: 4px;
@@ -314,8 +332,8 @@ Specimen Type <span>▾</span>
 <div id="facetNote" style="display: none; font-size: 11px; color: #888; margin-top: 4px; font-style: italic;">
 Material / feature / specimen filters apply at sample zoom level — zoom in or click a cluster.
 </div>
-<div style="margin-top: 8px; display: flex; gap: 8px; align-items: center;">
-<button id="shareBtn" class="share-btn" title="Copy link to current view">Share View</button>
+<div style="margin-top: 12px;">
+<button id="shareBtn" class="share-btn" title="Copy link to current view">Copy Link to Current View</button>
 <span id="shareToast" class="share-toast">Link copied!</span>
 </div>
 <div id="phaseMsg" class="phase-msg" style="margin-top: 8px; background: #e3f2fd; color: #1565c0;">
@@ -794,7 +812,7 @@ viewer = {
     const v = new Cesium.Viewer("cesiumContainer", {
         timeline: false,
         animation: false,
-        baseLayerPicker: false,
+        baseLayerPicker: true,
         fullscreenElement: "cesiumContainer",
         terrain: Cesium.Terrain.fromWorldTerrain()
     });
@@ -970,6 +988,8 @@ phase1 = {
             position: Cesium.Cartesian3.fromDegrees(row.center_lng, row.center_lat, 0),
             pixelSize: size,
             color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.8),
+            outlineColor: Cesium.Color.WHITE,
+            outlineWidth: 1.5,
             scaleByDistance: scalar,
         });
     }
@@ -1311,6 +1331,8 @@ zoomWatcher = {
                     position: Cesium.Cartesian3.fromDegrees(row.center_lng, row.center_lat, 0),
                     pixelSize: size,
                     color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.85),
+                    outlineColor: Cesium.Color.WHITE,
+                    outlineWidth: 1.5,
                     scaleByDistance: scalar,
                 });
             }
@@ -1463,6 +1485,8 @@ zoomWatcher = {
                 position: Cesium.Cartesian3.fromDegrees(row.longitude, row.latitude, 0),
                 pixelSize: 6,
                 color: Cesium.Color.fromCssColorString(color).withAlpha(0.9),
+                outlineColor: Cesium.Color.WHITE,
+                outlineWidth: 1.5,
                 scaleByDistance: scalar,
             });
         }


### PR DESCRIPTION
## Summary

Three visible-polish items from Hana's wireframe ([Figma 213:394](https://www.figma.com/design/Nqkuqh3Z4aqVh0nmwUAgKg/iSamples-Wireframe-1.0?node-id=213-394)), deferred from #178 as separate from the Light search-semantics work in #179.

- **Native Cesium control panel on left edge** — re-enable `baseLayerPicker` (was off) and reposition the Cesium toolbar from default top-right to a vertical strip on the top-left of the globe. `baseLayerPicker` dropdown opens to the right so it clears the side panel.
- **Prominent "Copy Link to Current View" button** — `#shareBtn` restyled full-width with larger padding and 14px font; label updated from "Share View" to match the mockup. Toast moves below the button.
- **Accessibility halos** — 1.5px white outline on all `PointPrimitive`s in both `h3Points` (cluster view) and `samplePoints` (sample view). Universal benefit (contrast on bright land + dark ocean alike), no toggle for v1.

## Verified locally

Manual browser eyeball at `http://localhost:5880/explorer.html` after `quarto render`:

| check | result |
|---|---|
| Cesium toolbar on left edge of globe, vertical | ✓ — 6 widgets stacked (geocoder, home, sceneModePicker, baseLayerPicker, navHelp, fullscreen) |
| `baseLayerPicker` dropdown opens to the right | ✓ — clears the side panel |
| Share button label + style | ✓ — "Copy Link to Current View", 316px wide, 14px / 10px padding, `#1565c0` |
| Halos visible on cluster dots | ✓ — orange/blue clusters crisp against both green land and blue ocean |
| Halos on sample-mode dots | ✓ — outline applied at the third point-add site |
| No console errors (other than benign `listings.json` 404) | ✓ |

## Out of scope (deferred — pending Hana's "corrections coming" revision)

From #178's mockup-derived items list, **not** in this PR:

- Quick Stats panel restructure (Selected Cluster merged into stats table)
- Permanent sample-rows table at bottom (conflicts with current Globe/Table toggle, needs UX call)
- Tree-selection vocabulary UI (Hana to provide diagram)
- Educational tooltips ("What is a Cluster?", "What is a Sample?") — needs copy
- Top-level sample-type icons (5 per category) — needs assets

Refs #178 (mockup integration umbrella). Companion to #179 (two-button search) which shipped earlier today.

## Test plan

- [ ] Open Explorer, confirm 6-widget toolbar on left edge of globe
- [ ] Click base-layer button — dropdown opens to the right, doesn't clip side panel
- [ ] Click home button — globe re-zooms to default view
- [ ] Click "Copy Link to Current View" — clipboard receives URL with hash, toast flashes "Link copied!" below the button
- [ ] Visually confirm white halos on cluster dots at world zoom and sample dots at street zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)