### PR TITLE
explorer: fix halo cutoff over terrain (disableDepthTestDistance)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -990,6 +990,7 @@ phase1 = {
             color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.8),
             outlineColor: Cesium.Color.WHITE,
             outlineWidth: 1.5,
+            disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: scalar,
         });
     }
@@ -1333,6 +1334,7 @@ zoomWatcher = {
                     color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.85),
                     outlineColor: Cesium.Color.WHITE,
                     outlineWidth: 1.5,
+                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
                     scaleByDistance: scalar,
                 });
             }
@@ -1487,6 +1489,7 @@ zoomWatcher = {
                 color: Cesium.Color.fromCssColorString(color).withAlpha(0.9),
                 outlineColor: Cesium.Color.WHITE,
                 outlineWidth: 1.5,
+                disableDepthTestDistance: Number.POSITIVE_INFINITY,
                 scaleByDistance: scalar,
             });
         }


### PR DESCRIPTION
## Summary

Hotfix for the halo regression introduced in #180.

The white halos exposed a **pre-existing** Cesium terrain depth-test artifact: PointPrimitives are positioned at altitude=0, so wherever Cesium World Terrain has elevation, the front face of the terrain mesh occludes part of the sprite. Without halos, that truncation read as a slightly smaller dot. With halos, the white ring made the cut glaringly obvious — appearing as crescents — and over higher terrain the sprite vanishes entirely.

**Reported view**: `explorer.html#v=1&lat=33.2706&lng=-86.2375&alt=311435` (Birmingham, AL hill country) — many dots showed only as half-moon halos or were entirely missing.

## Fix

Add `disableDepthTestDistance: Number.POSITIVE_INFINITY` to all three `PointPrimitive.add()` sites (h3Points x2 cluster-mode + samplePoints x1). This matches the existing pattern already used by `pointLabel` at line 843 — points render always-on-top regardless of intervening terrain.

## Trade-off

With depth test off, points on the **far side** of the globe could in principle bleed through. In practice at the zoom levels users hit (regional → world), the cluster aggregation hides this, and Cesium's frustum culling still removes truly back-facing primitives. Standard fix per Cesium docs.

## Verified locally

`quarto render` + Playwright at the reported camera (`lat=33.27, lng=-86.24, alt=311km`):

| check | result |
|---|---|
| Dots render as full circles, no crescents | ✓ |
| Dots over high terrain that were missing | ✓ visible |
| Halos still present (a11y win preserved) | ✓ |

## Test plan

- [ ] Visit `https://isamples.org/explorer.html#v=1&lat=33.2706&lng=-86.2375&alt=311435&heading=360.0` and confirm full-circle dots replace the previous crescents
- [ ] Other terrain-heavy regions: any mountainous area at street zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)