### PR TITLE
Revert "explorer: fix halo cutoff over terrain (disableDepthTestDistance)" (#181)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -990,7 +990,6 @@ phase1 = {
             color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.8),
             outlineColor: Cesium.Color.WHITE,
             outlineWidth: 1.5,
-            disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: scalar,
         });
     }
@@ -1334,7 +1333,6 @@ zoomWatcher = {
                     color: Cesium.Color.fromCssColorString(SOURCE_COLORS[row.dominant_source] || '#666').withAlpha(0.85),
                     outlineColor: Cesium.Color.WHITE,
                     outlineWidth: 1.5,
-                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
                     scaleByDistance: scalar,
                 });
             }
@@ -1489,7 +1487,6 @@ zoomWatcher = {
                 color: Cesium.Color.fromCssColorString(color).withAlpha(0.9),
                 outlineColor: Cesium.Color.WHITE,
                 outlineWidth: 1.5,
-                disableDepthTestDistance: Number.POSITIVE_INFINITY,
                 scaleByDistance: scalar,
             });
         }


### PR DESCRIPTION
Reverts #181 (`d681758`).

Reported behavior: ${\\textsf{terrible}}$ — disabling depth test on point primitives caused regressions worse than the original halo crescents. Rolling back so prod returns to post-#180 state while we have Codex review d681758 and propose a corrected fix.

Original issue (still open): halos added in #180 expose terrain depth-test occlusion as crescents on hilly land, and at close zoom the dots vanish entirely.

Next steps:
- Merge this revert + deploy to restore prod
- Codex review of `d681758` to identify a fix that doesn't regress whatever this just regressed
- Re-attempt halo terrain fix in a new PR

Refs #178, #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)