### PR TITLE
explorer: fix halo terrain occlusion via scene.globe.depthTestAgainstTerrain (v2)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -817,6 +817,14 @@ viewer = {
         terrain: Cesium.Terrain.fromWorldTerrain()
     });
 
+    // Surface-marker primitives (h3 clusters, sample dots) sit at altitude=0;
+    // World Terrain elevation otherwise occludes them, producing crescent halos
+    // and disappearing dots over hills (#180 regression). Disabling terrain
+    // depth-test draws primitives over terrain while preserving globe-ellipsoid
+    // occlusion (back-side primitives stay hidden) and pick correctness — unlike
+    // per-primitive `disableDepthTestDistance: Infinity`, which broke both.
+    v.scene.globe.depthTestAgainstTerrain = false;
+
     // URL deep-link state (must be set before globalRect/once block reads it)
     v._globeState = { mode: 'cluster', selectedPid: null };
     v._initialHash = readHash();


### PR DESCRIPTION
## Summary

Second attempt at the PR #180 halo terrain-occlusion bug. Replaces the reverted #181.

**Why #181 was wrong (Codex review of `d681758`):**
Setting `disableDepthTestDistance: Number.POSITIVE_INFINITY` on every `PointPrimitive` disables depth-test *entirely*, including against the globe ellipsoid. That caused two regressions worse than the original crescent halos:
1. **Back-side bleed-through** — points on the geographic far side of the globe rendered through the planet (the global H3 cluster collection makes this visible everywhere).
2. **Broken picking** — hover labels and click-handlers got routed to back-side primitives intersecting the screen ray.

**The correct fix (one line, scene-level):**

```js
v.scene.globe.depthTestAgainstTerrain = false;
```

Applied immediately after `Viewer` construction. This is the documented Cesium switch for "primitives at altitude=0 should draw over terrain elevation, but still respect ellipsoid back-face occlusion." It fixes the original crescent / disappearing-dots-over-hills problem **without** the d681758 regressions because:
- Globe ellipsoid depth-test still applies → back-side primitives still hidden.
- Scene-pick depth still works → hover and click correctness preserved.
- No per-primitive flags → no cross-cutting changes to the three `add()` sites.

The halos from #180 are untouched.

## Verified locally

`quarto render` + Playwright at two cameras:

| view | result |
|---|---|
| Reported repro: `lat=33.27, lng=-86.24, alt=311km` (Birmingham AL hill country) | ✓ full-circle halos, no crescents, dots over higher terrain visible |
| World view (Africa-centered) | ✓ globe occlusion intact, no back-side primitive bleed-through, edges crisp |

## Diff

8 lines — 1 line of actual code + 7 lines of comment explaining the Cesium-API choice and why per-primitive `disableDepthTestDistance` was wrong.

## Test plan

- [ ] Visit `https://isamples.org/explorer.html#v=1&lat=33.2706&lng=-86.2375&alt=311435&heading=360.0` — full-circle halos
- [ ] Mountainous regions (Rockies, Andes, Himalayas) at street zoom — dots remain visible
- [ ] World zoom — back side of globe stays hidden, no cluster bleed-through
- [ ] Hover and click on cluster + sample dots — correct primitive selected (no through-globe pick)

Refs #180, #181 (reverted), #183 (revert PR). Codex-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)