### PR TITLE
explorer: surface 'Fetching sample index…' during cold-cache boot→point-mode wait (#190 fix 2)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1604,6 +1604,44 @@ zoomWatcher = {
         console.log('Exited point mode');
     }
 
+    // --- Boot→point-mode transition (issue #190 fix 2) ---
+    //
+    // Idempotent helper that runs the cluster→point-mode transition iff the
+    // camera is currently at point-mode altitude. Called from two sites:
+    //
+    //  1. The camera-changed handler, when `targetMode === 'point' && mode
+    //     !== 'point'` — the normal cold-cache deep-link path.
+    //  2. The source-filter handler's `mode === 'cluster'` branch, after its
+    //     own `loadRes(currentRes, ...)` settles. Without this second call,
+    //     a source-filter toggle during the 60-90s cold-cache wait would
+    //     supersede the camera handler's pending res8 load (`loadResGen`++),
+    //     the camera handler's post-await re-check would correctly refuse
+    //     to enter point mode, and then no camera event would necessarily
+    //     fire to retry — leaving the user in cluster mode at point altitude
+    //     until they nudged the camera (issue #190 round-2 review).
+    //
+    // The function re-checks altitude/`mode` after its own (potentially
+    // long) `loadRes` await for the same reason: if the user zooms back out
+    // or another path enters point mode during the wait, we must not force
+    // entry afterwards.
+    async function tryEnterPointModeIfNeeded() {
+        if (mode === 'point') return;
+        if (viewer.camera.positionCartographic.height >= ENTER_POINT_ALT) return;
+
+        let res8Ready = currentRes === 8;
+        if (!res8Ready && !loading) {
+            res8Ready = await loadRes(8, h3_res8_url, {
+                loadingMsg: 'Fetching sample index…',
+                suppressDoneMsg: true,
+                errorMsg: 'Failed to fetch the sample index — try zooming out and back in.',
+            });
+        }
+        const hNow = viewer.camera.positionCartographic.height;
+        if (res8Ready && mode !== 'point' && hNow < ENTER_POINT_ALT) {
+            enterPointMode();
+        }
+    }
+
     // === Cross-filter facet count refresh (issue #156, Phase 2) ===
     //
     // Counts answer: for each value in facet D, how many samples would match
@@ -1770,6 +1808,16 @@ zoomWatcher = {
             if (mode === 'cluster') {
                 loading = false;
                 await loadRes(currentRes, resUrls[currentRes]);
+                // Liveness recovery (issue #190 round-2 review): if the user
+                // is sitting at point-mode altitude — e.g. they toggled the
+                // source filter mid-way through the cold-cache boot wait,
+                // which superseded the camera handler's pending res8 load —
+                // drive the cluster→point transition forward here. Without
+                // this, the user would stay in cluster mode at point altitude
+                // until they nudged the camera. The helper is idempotent and
+                // returns immediately if already in point mode or above the
+                // point-mode altitude threshold.
+                await tryEnterPointModeIfNeeded();
             } else {
                 cachedBounds = null;
                 await loadViewportSamples();
@@ -1862,45 +1910,12 @@ zoomWatcher = {
                              : mode;
 
             if (targetMode === 'point' && mode !== 'point') {
-                // Make sure we're at res8 clusters before transitioning.
-                //
-                // On a cold-cache deep-link to a point-mode altitude, this
-                // res8 fetch can take 60-90s while the 60 MB samples_map_lite
-                // file is also being pulled (DuckDB-WASM 1.24.0 falls back to
-                // a full HTTP read; see issue #190). During that wait the
-                // user sees the empty globe and no sample dots. Surface a
-                // boot-aware loading/error message pair so the user knows the
-                // page is busy fetching the index, not broken — and suppress
-                // the intermediate "Zoom closer for individual samples." done
-                // message that would otherwise flash before point mode
-                // overwrites it with its own "Loading individual samples…".
-                //
-                // Note: the override messages apply to any cluster→point
-                // transition where `currentRes !== 8`, including manual
-                // zoom-in, not only cold-cache boot. That's intentional —
-                // "Fetching sample index…" reads sensibly for both.
-                let res8Ready = currentRes === 8;
-                if (!res8Ready && !loading) {
-                    res8Ready = await loadRes(8, h3_res8_url, {
-                        loadingMsg: 'Fetching sample index…',
-                        suppressDoneMsg: true,
-                        errorMsg: 'Failed to fetch the sample index — try zooming out and back in.',
-                    });
-                }
-                // Re-check preconditions after the (potentially 60-90s) await:
-                //  - `res8Ready` is false if our load was superseded by a newer
-                //    `loadRes` (e.g. a source-filter change that fired
-                //    `loadRes(currentRes=4, ...)` while we were still waiting)
-                //    or if it failed. In either case `currentRes` may not be 8
-                //    and entering point mode would render dots over the wrong
-                //    cluster index.
-                //  - The user may have zoomed back out during the wait, so
-                //    altitude is no longer in the point-mode regime.
-                //  - Another path may have already entered point mode.
-                const hNow = viewer.camera.positionCartographic.height;
-                if (res8Ready && mode !== 'point' && hNow < ENTER_POINT_ALT) {
-                    enterPointMode();
-                }
+                // Cold-cache deep-link: the res8 + samples_map_lite fetches
+                // can take 60-90s (DuckDB-WASM 1.24.0 falls back to a full
+                // HTTP read; see issue #190). Delegate to the shared helper
+                // so the source-filter handler can call the same path on
+                // supersession recovery.
+                await tryEnterPointModeIfNeeded();
             } else if (targetMode === 'cluster' && mode !== 'cluster') {
                 exitPointMode();
                 // Reload appropriate resolution

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1351,10 +1351,17 @@ zoomWatcher = {
 
     // --- H3 cluster loading (existing logic) ---
     //
-    // `opts.loadingMsg` overrides the default "Loading H3 res${res}..." phase
-    // text. Used by the boot→point-mode path so the user sees a coherent
-    // "Fetching sample index…" message during the cold-cache wait (issue #190
-    // fix 2) instead of internal "H3 res8" jargon.
+    // `opts.loadingMsg` / `opts.errorMsg` override the default phase text so
+    // callers like the boot→point-mode path can show a coherent
+    // "Fetching sample index…" / "Failed to fetch the sample index…" pair
+    // (issue #190 fix 2) instead of internal "H3 res8" jargon.
+    //
+    // Return value: `true` if this call applied fresh data and `currentRes`
+    // is now `res`; `false` if the call was superseded by a newer one (stale
+    // generation) or failed. Callers that gate follow-up work on the cluster
+    // resolution being ready (e.g. the camera handler before `enterPointMode`)
+    // must use the return value rather than treating a normal `await` return
+    // as success.
     let loadResGen = 0;  // generation counter to discard stale results
     const loadRes = async (res, url, opts = {}) => {
         const gen = ++loadResGen;  // claim a generation
@@ -1371,7 +1378,7 @@ zoomWatcher = {
                 WHERE 1=1${sourceFilterSQL('dominant_source')}
             `);
 
-            if (gen !== loadResGen) return;  // stale — a newer call superseded this one
+            if (gen !== loadResGen) return false;  // stale — a newer call superseded this one
             viewer.h3Points.removeAll();
             const scalar = new Cesium.NearFarScalar(1.5e2, 1.5, 8.0e6, 0.3);
             let total = 0;
@@ -1415,11 +1422,20 @@ zoomWatcher = {
 
             currentRes = res;
             console.log(`Res${res}: ${data.length} clusters in ${elapsed.toFixed(0)}ms`);
+            return true;
         } catch(err) {
+            // Same generation guard as the success path — a stale failure
+            // must not overwrite UI state owned by a newer in-flight call.
+            if (gen !== loadResGen) return false;
             console.error(`Failed to load res${res}:`, err);
-            updatePhaseMsg(`Failed to load H3 res${res} — try zooming again.`, 'loading');
+            updatePhaseMsg(opts.errorMsg || `Failed to load H3 res${res} — try zooming again.`, 'loading');
+            return false;
         } finally {
-            loading = false;
+            // Only release the busy flag if we're still the current generation.
+            // A stale call's `finally` running after a newer call has set
+            // `loading = true` would otherwise clear the flag while the newer
+            // load is still in flight.
+            if (gen === loadResGen) loading = false;
         }
     };
 
@@ -1853,18 +1869,38 @@ zoomWatcher = {
                 // file is also being pulled (DuckDB-WASM 1.24.0 falls back to
                 // a full HTTP read; see issue #190). During that wait the
                 // user sees the empty globe and no sample dots. Surface a
-                // boot-aware loading message so the user knows the page is
-                // busy fetching the index, not broken — and suppress the
-                // intermediate "Zoom closer for individual samples." done
+                // boot-aware loading/error message pair so the user knows the
+                // page is busy fetching the index, not broken — and suppress
+                // the intermediate "Zoom closer for individual samples." done
                 // message that would otherwise flash before point mode
                 // overwrites it with its own "Loading individual samples…".
-                if (currentRes !== 8 && !loading) {
-                    await loadRes(8, h3_res8_url, {
+                //
+                // Note: the override messages apply to any cluster→point
+                // transition where `currentRes !== 8`, including manual
+                // zoom-in, not only cold-cache boot. That's intentional —
+                // "Fetching sample index…" reads sensibly for both.
+                let res8Ready = currentRes === 8;
+                if (!res8Ready && !loading) {
+                    res8Ready = await loadRes(8, h3_res8_url, {
                         loadingMsg: 'Fetching sample index…',
                         suppressDoneMsg: true,
+                        errorMsg: 'Failed to fetch the sample index — try zooming out and back in.',
                     });
                 }
-                enterPointMode();
+                // Re-check preconditions after the (potentially 60-90s) await:
+                //  - `res8Ready` is false if our load was superseded by a newer
+                //    `loadRes` (e.g. a source-filter change that fired
+                //    `loadRes(currentRes=4, ...)` while we were still waiting)
+                //    or if it failed. In either case `currentRes` may not be 8
+                //    and entering point mode would render dots over the wrong
+                //    cluster index.
+                //  - The user may have zoomed back out during the wait, so
+                //    altitude is no longer in the point-mode regime.
+                //  - Another path may have already entered point mode.
+                const hNow = viewer.camera.positionCartographic.height;
+                if (res8Ready && mode !== 'point' && hNow < ENTER_POINT_ALT) {
+                    enterPointMode();
+                }
             } else if (targetMode === 'cluster' && mode !== 'cluster') {
                 exitPointMode();
                 // Reload appropriate resolution

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1350,11 +1350,16 @@ zoomWatcher = {
     let cachedData = null;    // array of rows
 
     // --- H3 cluster loading (existing logic) ---
+    //
+    // `opts.loadingMsg` overrides the default "Loading H3 res${res}..." phase
+    // text. Used by the boot→point-mode path so the user sees a coherent
+    // "Fetching sample index…" message during the cold-cache wait (issue #190
+    // fix 2) instead of internal "H3 res8" jargon.
     let loadResGen = 0;  // generation counter to discard stale results
-    const loadRes = async (res, url) => {
+    const loadRes = async (res, url, opts = {}) => {
         const gen = ++loadResGen;  // claim a generation
         loading = true;
-        updatePhaseMsg(`Loading H3 res${res}...`, 'loading');
+        updatePhaseMsg(opts.loadingMsg || `Loading H3 res${res}...`, 'loading');
 
         try {
             performance.mark(`r${res}-s`);
@@ -1398,7 +1403,15 @@ zoomWatcher = {
             const bounds = getViewportBounds();
             const inView = countInViewport(bounds);
             updateStats(`H3 Res${res}`, `${inView.clusters.toLocaleString()} / ${data.length.toLocaleString()}`, inView.samples.toLocaleString(), `${(elapsed/1000).toFixed(1)}s`, 'Clusters in View / Loaded', 'Samples in View');
-            updatePhaseMsg(`${data.length.toLocaleString()} clusters, ${total.toLocaleString()} samples. ${res < 8 ? 'Zoom in for finer detail.' : 'Zoom closer for individual samples.'}`, 'done');
+            // Skip the "Zoom closer for individual samples." done message when
+            // the caller is about to transition into point mode itself — the
+            // next step (loadViewportSamples) immediately overwrites it with
+            // its own "Loading individual samples…" loading state, so flashing
+            // a misleading "zoom closer" hint at a user who is already deep
+            // in point altitude is just noise (issue #190 fix 2).
+            if (!opts.suppressDoneMsg) {
+                updatePhaseMsg(`${data.length.toLocaleString()} clusters, ${total.toLocaleString()} samples. ${res < 8 ? 'Zoom in for finer detail.' : 'Zoom closer for individual samples.'}`, 'done');
+            }
 
             currentRes = res;
             console.log(`Res${res}: ${data.length} clusters in ${elapsed.toFixed(0)}ms`);
@@ -1833,9 +1846,23 @@ zoomWatcher = {
                              : mode;
 
             if (targetMode === 'point' && mode !== 'point') {
-                // Make sure we're at res8 clusters before transitioning
+                // Make sure we're at res8 clusters before transitioning.
+                //
+                // On a cold-cache deep-link to a point-mode altitude, this
+                // res8 fetch can take 60-90s while the 60 MB samples_map_lite
+                // file is also being pulled (DuckDB-WASM 1.24.0 falls back to
+                // a full HTTP read; see issue #190). During that wait the
+                // user sees the empty globe and no sample dots. Surface a
+                // boot-aware loading message so the user knows the page is
+                // busy fetching the index, not broken — and suppress the
+                // intermediate "Zoom closer for individual samples." done
+                // message that would otherwise flash before point mode
+                // overwrites it with its own "Loading individual samples…".
                 if (currentRes !== 8 && !loading) {
-                    await loadRes(8, h3_res8_url);
+                    await loadRes(8, h3_res8_url, {
+                        loadingMsg: 'Fetching sample index…',
+                        suppressDoneMsg: true,
+                    });
                 }
                 enterPointMode();
             } else if (targetMode === 'cluster' && mode !== 'cluster') {

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1607,7 +1607,7 @@ zoomWatcher = {
     // --- Boot→point-mode transition (issue #190 fix 2) ---
     //
     // Idempotent helper that runs the cluster→point-mode transition iff the
-    // camera is currently at point-mode altitude. Called from two sites:
+    // camera is currently at point-mode altitude. Called from three paths:
     //
     //  1. The camera-changed handler, when `targetMode === 'point' && mode
     //     !== 'point'` — the normal cold-cache deep-link path.
@@ -1619,6 +1619,10 @@ zoomWatcher = {
     //     to enter point mode, and then no camera event would necessarily
     //     fire to retry — leaving the user in cluster mode at point altitude
     //     until they nudged the camera (issue #190 round-2 review).
+    //  3. The camera handler's cluster-resolution reload branches, after
+    //     their `loadRes(target, ...)` settles. This covers the same liveness
+    //     shape when a camera-initiated cluster load was already in flight as
+    //     the user crossed into point altitude.
     //
     // The function re-checks altitude/`mode` after its own (potentially
     // long) `loadRes` await for the same reason: if the user zooms back out
@@ -1922,6 +1926,10 @@ zoomWatcher = {
                 const target = h > 3000000 ? 4 : h > 300000 ? 6 : 8;
                 if (target !== currentRes && !loading) {
                     await loadRes(target, { 4: h3_res4_url, 6: h3_res6_url, 8: h3_res8_url }[target]);
+                    // The user may have crossed below ENTER_POINT_ALT while
+                    // this cluster load was in flight; reconcile after it
+                    // settles so no extra camera nudge is required.
+                    await tryEnterPointModeIfNeeded();
                 }
             } else if (targetMode === 'point') {
                 // Already in point mode — update viewport samples
@@ -1931,6 +1939,10 @@ zoomWatcher = {
                 const target = h > 3000000 ? 4 : h > 300000 ? 6 : 8;
                 if (target !== currentRes && !loading) {
                     await loadRes(target, { 4: h3_res4_url, 6: h3_res6_url, 8: h3_res8_url }[target]);
+                    // The user may have crossed below ENTER_POINT_ALT while
+                    // this cluster load was in flight; reconcile after it
+                    // settles so no extra camera nudge is required.
+                    await tryEnterPointModeIfNeeded();
                 }
             }
 


### PR DESCRIPTION
## Summary

Implements **fix 2** from #190 — surfaces a coherent loading message during the cold-cache `boot→point-mode` gap so deep-links to a point-mode altitude don't look broken during the 60-90s wait. Three review rounds also tightened underlying race / liveness bugs in `loadRes` that the longer user-visible window made unsafe.

Independent of fix 1 (move off Quarto's bundled DuckDB-WASM 1.24.0), which is blocked on UBIGINT representation changes in newer wasm builds (see [spike result comment](https://github.com/isamplesorg/isamplesorg.github.io/issues/190#issuecomment-4414452920)).

### Phase-message sequence (cold-cache deep-link, alt < 120 km)

**Before:**
1. `Loading H3 res8...` — internal jargon, fires ~immediately, persists ~85 s
2. `175,653 clusters, X samples. Zoom closer for individual samples.` — flashes for one frame; misleading because the user is *already* zoomed in
3. `Loading individual samples...` — fires from inside `loadViewportSamples`
4. `47 individual samples. Click one for details.`

**After:**
1. `Fetching sample index…` — fires ~immediately, persists during the cold-cache wait
2. `Loading individual samples...`
3. `47 individual samples. Click one for details.`

On failure: `Failed to fetch the sample index — try zooming out and back in.` (instead of `Failed to load H3 res8 — try zooming again.`).

### Implementation (final state)

#### 1. New `loadRes` opts (round 1)
- `opts.loadingMsg` — override the default `"Loading H3 res${res}..."` text.
- `opts.suppressDoneMsg` — skip the interim `"... Zoom closer for individual samples."` done message that would otherwise flash before point mode overwrites it.
- `opts.errorMsg` — override the default `"Failed to load H3 res${res} — try zooming again."` failure copy.

#### 2. Hardened `loadRes` race contract (round 2)
- Returns `true` only when fresh data was applied and `currentRes = res`; `false` on stale-generation supersession or caught failure. Callers that gate follow-up work on the cluster resolution being ready (e.g. before `enterPointMode`) must use the return value.
- `catch` block now has the same generation guard as the success path, so a stale failure can't overwrite UI state owned by a newer in-flight call.
- `finally` only releases the `loading` busy-flag if the call is still the current generation, so a stale call's cleanup can't clear the flag while a newer load is still in flight.

#### 3. Idempotent `tryEnterPointModeIfNeeded()` helper (round 3 + 5bb5a78)
Centralizes the cluster→point transition. Called from four `loadRes` sites that could be in-flight when the user crosses below `ENTER_POINT_ALT`:
- The camera handler's `targetMode === 'point' && mode !== 'point'` branch (the original cold-cache deep-link path).
- The camera handler's two cluster-resolution-reload branches (5bb5a78).
- The source-filter handler's `mode === 'cluster'` branch, after its own `loadRes(currentRes, ...)` settles.

The helper short-circuits if already in point mode or above `ENTER_POINT_ALT`, and re-checks both after its own (potentially long) `loadRes` await. Closes the supersession liveness gap where a source-filter toggle during the boot wait would supersede the camera handler's pending res8 load and strand the user in cluster mode at point altitude until they nudged the camera.

### Stats

+101/-12 across four commits, all in `explorer.qmd`. No tests added (deterministic parts of `tryEnterPointModeIfNeeded` would benefit from Playwright coverage — tracked as a follow-up).

## Test plan

- [ ] **Cold-cache deep-link to point mode** — fresh browser profile / cache disabled. Visit https://isamples.org/explorer.html#v=1&lat=34.9954&lng=33.7052&alt=62054&heading=360.0&mode=point&h3=882da6b2e1fffff and confirm `Fetching sample index…` appears and persists until sample dots render, with no `Loading H3 res8...` or `Zoom closer for individual samples.` flashes in between.
- [ ] **Wider deep-link (alt > 180 km, cluster mode)** — confirm phase messages are unchanged (still `Loading H3 res${res}...` → `${count} clusters, ${samples} samples. Zoom in for finer detail.`).
- [ ] **Source-filter toggle while in cluster mode (warm cache)** — confirm `Loading H3 res${res}...` still appears (default loadRes message), no spurious `Fetching sample index…` flicker because the helper short-circuits at the altitude check.
- [ ] **Source-filter toggle during cold-cache boot wait** (the round-3 race) — toggle a source filter while `Fetching sample index…` is showing. Confirm: phase message switches to `Loading H3 res${currentRes}...` while the source-filter's loadRes runs, then back to `Fetching sample index…` for the recovery loadRes(8), then point mode is entered. **Do not** end up in cluster mode at point altitude.
- [ ] **Source-filter toggle while in point mode** — confirm `Loading individual samples...` still appears.
- [ ] **Camera zoom from cluster → point mode (warm cache)** — confirm transition still works.
- [ ] **Cluster-mode resolution change while crossing into point altitude** (round-3.5 race, 5bb5a78) — start in cluster mode, fast-zoom past res4→res6→res8 thresholds straight into point altitude. Confirm point mode is entered without requiring a manual camera nudge.

## Follow-ups (post-merge)

Three follow-up issues filed:

1. #192 — **Playwright coverage for `tryEnterPointModeIfNeeded` invariants** — short-circuit at `mode === 'point'` / above `ENTER_POINT_ALT`, source-filter→cluster chase path, supersession recovery.
2. #193 — **Smooth the rare failure-message flicker** when a chased `tryEnterPointModeIfNeeded()` call paints `Fetching sample index…` over a just-painted `Failed to load H3 res${target}` from a failed cluster reload.
3. #194 — **Document the "every `loadRes` caller chases with `tryEnterPointModeIfNeeded`" invariant** near the helper definition, to make the supersession-recovery contract self-evident for future contributors adding new `loadRes` sites.

## Refs

- #190 — parent issue (DuckDB-WASM 1.24.0 falls back to full HTTP read; this PR ships the UX-side mitigation independently of the runtime version bump)
- [Spike comment](https://github.com/isamplesorg/isamplesorg.github.io/issues/190#issuecomment-4414452920) — why the version bump can't ship as a one-liner today

🤖 Generated with [Claude Code](https://claude.com/claude-code)
