### PR TITLE
explorer: document loadRes-chase invariant on tryEnterPointModeIfNeeded (closes #194)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1629,17 +1629,18 @@ zoomWatcher = {
     // or another path enters point mode during the wait, we must not force
     // entry afterwards.
     //
-    // INVARIANT: every `loadRes` call site in this cell that could be in
-    // flight when the user crosses below `ENTER_POINT_ALT` MUST be followed
-    // by `await tryEnterPointModeIfNeeded()`. The `!loading` short-circuit
-    // below relies on this — when an unrelated `loadRes` is in flight we
-    // bail and leave recovery to that call site's own post-await chase. A
-    // new `loadRes` caller added without the chase would silently break
-    // supersession recovery and only surface as a rare liveness regression
-    // (see issue #194). Verify with:
-    //   grep -nE "loadRes\(" explorer.qmd
-    // and check each match either lives inside `tryEnterPointModeIfNeeded`
-    // itself or is followed by a chase call.
+    // INVARIANT: every `loadRes` call site in this cell *outside this
+    // helper* that could be in flight when the user crosses below
+    // `ENTER_POINT_ALT` MUST be followed by `await tryEnterPointModeIfNeeded()`.
+    // The `!loading` short-circuit below relies on this — when an unrelated
+    // `loadRes` is in flight we bail and leave recovery to that call site's
+    // own post-await chase. A new `loadRes` caller added without the chase
+    // would silently break supersession recovery and only surface as a rare
+    // liveness regression (see issue #194). Verify with:
+    //   grep -nE "await[[:space:]]+loadRes\(" explorer.qmd
+    // which lists exactly the awaited call sites (one inside this helper,
+    // and one per external caller). For each external match, confirm it is
+    // immediately followed by `await tryEnterPointModeIfNeeded()`.
     async function tryEnterPointModeIfNeeded() {
         if (mode === 'point') return;
         if (viewer.camera.positionCartographic.height >= ENTER_POINT_ALT) return;

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1628,11 +1628,26 @@ zoomWatcher = {
     // long) `loadRes` await for the same reason: if the user zooms back out
     // or another path enters point mode during the wait, we must not force
     // entry afterwards.
+    //
+    // INVARIANT: every `loadRes` call site in this cell that could be in
+    // flight when the user crosses below `ENTER_POINT_ALT` MUST be followed
+    // by `await tryEnterPointModeIfNeeded()`. The `!loading` short-circuit
+    // below relies on this — when an unrelated `loadRes` is in flight we
+    // bail and leave recovery to that call site's own post-await chase. A
+    // new `loadRes` caller added without the chase would silently break
+    // supersession recovery and only surface as a rare liveness regression
+    // (see issue #194). Verify with:
+    //   grep -nE "loadRes\(" explorer.qmd
+    // and check each match either lives inside `tryEnterPointModeIfNeeded`
+    // itself or is followed by a chase call.
     async function tryEnterPointModeIfNeeded() {
         if (mode === 'point') return;
         if (viewer.camera.positionCartographic.height >= ENTER_POINT_ALT) return;
 
         let res8Ready = currentRes === 8;
+        // See INVARIANT above: if an unrelated load is in flight, that
+        // call site is responsible for chasing with this helper when it
+        // settles. Don't second-guess it from here.
         if (!res8Ready && !loading) {
             res8Ready = await loadRes(8, h3_res8_url, {
                 loadingMsg: 'Fetching sample index…',


### PR DESCRIPTION
## Summary

Closes #194. Doc-only change to `explorer.qmd` — adds a load-bearing **INVARIANT** block to the doc comment of `tryEnterPointModeIfNeeded()` plus a short pointer above the `!loading` short-circuit inside the function.

The invariant: every `loadRes` call site in the `zoomWatcher` cell that could be in flight when the user crosses below `ENTER_POINT_ALT` MUST be followed by `await tryEnterPointModeIfNeeded()`. Without the chase, the helper's `!loading` bail-out can strand the user in cluster mode at point altitude — the exact bug round 3 of #191 fixed by adding the source-filter handler's chase call.

## Why this matters

Future contributors adding a new `loadRes` site without the chase would silently break supersession recovery. The bug would surface only as a rare liveness regression (user at point altitude, mode stays cluster, no further events fire) that's hard to attribute back to the missing chase. The PR thread for #191 documented this; this PR moves it to the code itself.

## Test plan

- [ ] No behavior change — `quarto render explorer.qmd` produces identical output to main.
- [ ] `grep -nE 'loadRes\(' explorer.qmd` returns the same set of call sites as main, each either inside `tryEnterPointModeIfNeeded` itself or followed by `await tryEnterPointModeIfNeeded()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)