### PR TITLE
explorer: add camera.moveEnd URL-write backstop (closes #204)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -2042,6 +2042,21 @@ zoomWatcher = {
     });
     viewer.camera.percentageChanged = 0.1;
 
+    // Backstop URL-write trigger (issue #204). `camera.changed` is suppressed
+    // for sub-`percentageChanged` moves, so a small drag-pan that doesn't
+    // cross the 10% threshold never schedules the debounced callback above —
+    // and the URL stays stale until a larger move fires the event. `moveEnd`
+    // fires once per discrete settled camera move regardless of magnitude
+    // (mouseup on a drag, wheel-stop on a zoom, flight-complete on flyTo),
+    // so this catches every camera position the user can pan/zoom to.
+    // The `_suppressHashWrite` gate keeps the hashchange-flight path
+    // unaffected.
+    viewer.camera.moveEnd.addEventListener(() => {
+        if (!viewer._suppressHashWrite) {
+            history.replaceState(null, '', buildHash(viewer));
+        }
+    });
+
     // --- Helper: hydrate cluster row from H3 cell index ---
     // Canonical H3 cells encode resolution in the 2nd hex char (the leading-zero-
     // stripped form is `8<res><...>` for cell-mode indices). We support res 4/6/8


### PR DESCRIPTION
Closes #204. Follow-up to #203.

## Problem

#203 fixed the await-blocking case for Bug A but the harness against the deployed site revealed a residual: small camera moves below Cesium's `percentageChanged = 0.1` threshold don't fire `camera.changed`, so the URL write is never scheduled. A user who pans a small distance and immediately copies the URL gets stale state. Empirically reproduced on iter 2 of `url_roundtrip_investigation.js` (Δlat ≈ 0.02° pan only, no zoom).

## Fix

Add `viewer.camera.moveEnd` as a parallel URL-write trigger. It fires once per discrete settled camera move regardless of magnitude — covers drag-pan mouseup, wheel-stop, flight-complete on flyTo. The existing `camera.changed` handler keeps its role (mode transitions, resolution loads); this just adds a lightweight URL-only backstop.

The `_suppressHashWrite` gate already handles the hashchange-flight path, so no fight with back/forward navigation.

## Verification

`tests/playwright/url_roundtrip_investigation.js` against localhost on this branch — all 6 iterations pass (cf. iter 2 still failing on the post-#203 deploy).

## Risks

- **Double writes for big camera moves**: `camera.changed` and `moveEnd` will both fire for above-threshold moves. Both are `replaceState` (no history-entry growth) and write the same value at settle, so the second write is idempotent. Acceptable cost for the small-move coverage.
- **flyTo`-triggered writes**: `moveEnd` fires on programmatic flights too. The `_suppressHashWrite` flag is set during hashchange flights (`explorer.qmd:2139`), so back/forward hydration paths are still respected. Other flights (click handlers, source-filter rebuild) intentionally want the URL updated — same as today's behavior.

## Test plan

- [x] Harness passes all 6 iterations against localhost (Quarto preview, this branch)
- [ ] Smoke on deploy preview: small pan only → copy URL → paste → matches
- [ ] Codex review (optional but recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)