### PR TITLE
explorer: URL state contract micro-fixes (closes #207)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -2226,12 +2226,17 @@ zoomWatcher = {
             duration: 1.5,
         });
 
-        // After flight settles, force mode and clear suppress flag
+        // After flight settles, force mode and clear suppress flag.
+        // Use the same altitude-authoritative predicate as the boot path
+        // (issue #207 item 4 → Codex follow-up): without this, back/forward
+        // through a `#alt=8000` URL with no `mode=point` would exit point
+        // mode here even though boot would have entered it.
         viewer._suppressTimer = setTimeout(() => {
             viewer._suppressHashWrite = false;
             const s = readHash();
-            if (s.mode === 'point' && mode !== 'point') enterPointMode(false);
-            else if (s.mode !== 'point' && mode === 'point') exitPointMode(false);
+            const wantsPoint = s.mode === 'point' || (s.alt != null && s.alt < ENTER_POINT_ALT);
+            if (wantsPoint && mode !== 'point') enterPointMode(false);
+            else if (!wantsPoint && mode === 'point') exitPointMode(false);
         }, 2000);
 
         // Handle pid / h3 selection (sample mode wins if both present — see
@@ -2497,29 +2502,60 @@ zoomWatcher = {
                 }
                 sampEl.innerHTML = h;
 
-                // Click search result → fly to it AND set it as the
-                // selected sample (issue #207 item 8). Without the
-                // selection write, the URL captured at flight settle
-                // would carry whatever prior pid/h3 was selected,
-                // misrepresenting the user's actual view in any paste-
-                // elsewhere flow.
+                // Click search result → treat as a full selection event
+                // (issue #207 item 8 → Codex follow-up): freshness token
+                // bump, sample-card hydration, selection state, flight,
+                // and lazy detail load — matching the on-globe sample
+                // click ceremony at line ~944. Without the full ceremony
+                // a slow prior selection load could repaint the panel
+                // after the click, leaving UI inconsistent with URL.
+                const resultsByPid = new Map(results.map(s => [s.pid, s]));
                 sampEl.querySelectorAll('.sample-row[data-lat]').forEach(row => {
-                    row.addEventListener('click', (e) => {
+                    row.addEventListener('click', async (e) => {
                         if (e.target.tagName === 'A') return; // let links work
-                        const lat = parseFloat(row.dataset.lat);
-                        const lng = parseFloat(row.dataset.lng);
                         const pid = row.dataset.pid;
-                        if (!isNaN(lat) && !isNaN(lng)) {
-                            // Update selection BEFORE the flight so that
-                            // moveEnd's buildHash captures the new pid.
-                            if (pid) {
-                                viewer._globeState.selectedPid = pid;
-                                viewer._globeState.selectedH3 = null;
-                            }
-                            viewer.camera.flyTo({
-                                destination: Cesium.Cartesian3.fromDegrees(lng, lat, 50000),
-                                duration: 1.5
-                            });
+                        const sample = pid ? resultsByPid.get(pid) : null;
+                        if (!sample || sample.latitude == null || sample.longitude == null) return;
+
+                        // Bump the freshness token BEFORE any async work so
+                        // a prior cluster/sample detail load can't repaint
+                        // the panel after we navigate.
+                        const isStale = freshSelectionToken(viewer);
+
+                        viewer._globeState.selectedPid = pid;
+                        viewer._globeState.selectedH3 = null;
+                        updateSampleCard({
+                            pid: sample.pid,
+                            label: sample.label,
+                            source: sample.source,
+                            lat: sample.latitude,
+                            lng: sample.longitude,
+                            place_name: sample.place_name,
+                            result_time: sample.result_time
+                        });
+                        viewer.camera.flyTo({
+                            destination: Cesium.Cartesian3.fromDegrees(sample.longitude, sample.latitude, 50000),
+                            duration: 1.5
+                        });
+
+                        // Lazy-load full description (mirrors the globe
+                        // click handler). Don't clear samplesSection here —
+                        // it currently holds the search results the user
+                        // is browsing.
+                        try {
+                            const detail = await db.query(`
+                                SELECT description
+                                FROM read_parquet('${wide_url}')
+                                WHERE pid = '${pid.replace(/'/g, "''")}'
+                                LIMIT 1
+                            `);
+                            if (isStale()) return;
+                            if (detail && detail.length > 0) updateSampleDetail(detail[0]);
+                            else updateSampleDetail({ description: '' });
+                        } catch(err) {
+                            if (isStale()) return;
+                            console.error("Search-row detail query failed:", err);
+                            updateSampleDetail(null);
                         }
                     });
                 });

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -1738,7 +1738,7 @@ zoomWatcher = {
     // and one per external caller). For each external match, confirm it
     // captures the return into `applied` and is immediately followed by
     // `if (applied) await tryEnterPointModeIfNeeded();`.
-    async function tryEnterPointModeIfNeeded() {
+    async function tryEnterPointModeIfNeeded(opts) {
         if (mode === 'point') return;
         if (viewer.camera.positionCartographic.height >= ENTER_POINT_ALT) return;
 
@@ -1755,7 +1755,9 @@ zoomWatcher = {
         }
         const hNow = viewer.camera.positionCartographic.height;
         if (res8Ready && mode !== 'point' && hNow < ENTER_POINT_ALT) {
-            enterPointMode();
+            // Propagate `pushHistory` so boot/hash hydration callers can
+            // avoid growing the browser history stack (issue #207 item 3).
+            enterPointMode(opts && opts.pushHistory);
         }
     }
 
@@ -2269,8 +2271,13 @@ zoomWatcher = {
                 viewer._globeState.selectedH3 = meta.h3_cell;  // canonical lowercase
                 await hydrateClusterUI(meta, isStale);
             } else {
-                // Unknown / malformed h3 — clear the side panel rather than
-                // leaving prior content stranded.
+                // Unknown / malformed h3, OR filtered out by ?sources= —
+                // clear the side panel rather than leaving prior content
+                // stranded, AND drop the h3 from runtime state so
+                // buildHash() doesn't keep emitting it (issue #207 item 6:
+                // restores symmetry with the boot deep-link path which
+                // already does this).
+                viewer._globeState.selectedH3 = null;
                 updateClusterCard(null);
                 const sampEl = document.getElementById('samplesSection');
                 if (sampEl) sampEl.innerHTML = '';
@@ -2490,7 +2497,12 @@ zoomWatcher = {
                 }
                 sampEl.innerHTML = h;
 
-                // Click search result → fly to it
+                // Click search result → fly to it AND set it as the
+                // selected sample (issue #207 item 8). Without the
+                // selection write, the URL captured at flight settle
+                // would carry whatever prior pid/h3 was selected,
+                // misrepresenting the user's actual view in any paste-
+                // elsewhere flow.
                 sampEl.querySelectorAll('.sample-row[data-lat]').forEach(row => {
                     row.addEventListener('click', (e) => {
                         if (e.target.tagName === 'A') return; // let links work
@@ -2498,6 +2510,12 @@ zoomWatcher = {
                         const lng = parseFloat(row.dataset.lng);
                         const pid = row.dataset.pid;
                         if (!isNaN(lat) && !isNaN(lng)) {
+                            // Update selection BEFORE the flight so that
+                            // moveEnd's buildHash captures the new pid.
+                            if (pid) {
+                                viewer._globeState.selectedPid = pid;
+                                viewer._globeState.selectedH3 = null;
+                            }
                             viewer.camera.flyTo({
                                 destination: Cesium.Cartesian3.fromDegrees(lng, lat, 50000),
                                 duration: 1.5
@@ -2510,7 +2528,15 @@ zoomWatcher = {
             // Fly to the first result. Skip for area-scoped searches —
             // the user is already at the area they care about; flying
             // would zoom in and disorient.
+            //
+            // Auto-flight is a NUDGE, not an explicit selection — clear
+            // any prior selectedPid/selectedH3 so the resulting URL
+            // doesn't carry stale selection state across the flight
+            // (issue #207 item 8). User clicks on a specific row to
+            // establish a new selection.
             if (effectiveScope === 'world' && results[0].latitude && results[0].longitude) {
+                viewer._globeState.selectedPid = null;
+                viewer._globeState.selectedH3 = null;
                 viewer.camera.flyTo({
                     destination: Cesium.Cartesian3.fromDegrees(results[0].longitude, results[0].latitude, 200000),
                     duration: 1.5
@@ -2672,17 +2698,27 @@ zoomWatcher = {
         viewer._suppressHashWrite = false;
     }
 
-    // Deep-link mode hydration (issue #201, Bug B). The boot path positions
-    // the camera via `camera.setView`, which in some cases (notably when the
-    // URL omits `heading` — i.e. heading defaults to 0 — at point altitudes)
-    // does not raise `camera.changed`, so the camera-changed handler never
-    // runs and the URL's `mode=point` is silently ignored. Drive the mode
-    // transition explicitly here so the boot is independent of whether
-    // `setView` happened to fire the event. `tryEnterPointModeIfNeeded()`
+    // Deep-link mode hydration (issue #201 Bug B + issue #207 item 4).
+    // The boot path positions the camera via `camera.setView`, which in
+    // some cases (notably when the URL omits `heading` — i.e. heading
+    // defaults to 0 — at point altitudes) does not raise `camera.changed`,
+    // so the camera-changed handler never runs and the URL's `mode=point`
+    // is silently ignored. Drive the mode transition explicitly here so
+    // the boot is independent of whether `setView` happened to fire the
+    // event.
+    //
+    // Trigger on EITHER `ih.mode === 'point'` OR low altitude (< ENTER_POINT_ALT).
+    // The altitude branch closes the loophole introduced by #203's early
+    // URL write: a user copying mid-transition can produce a URL like
+    // `alt=8000` *without* `mode=point`, which previously round-tripped
+    // as cluster mode at low altitude. Now boot enters point mode for
+    // any URL whose altitude says it should. `tryEnterPointModeIfNeeded()`
     // short-circuits if alt >= ENTER_POINT_ALT or we're already in point
-    // mode, so this is a no-op for cluster deep-links.
-    if (ih.mode === 'point') {
-        await tryEnterPointModeIfNeeded();
+    // mode, so this is a no-op for cluster deep-links at cluster altitude.
+    if (ih.mode === 'point' || (ih.alt != null && ih.alt < ENTER_POINT_ALT)) {
+        // pushHistory: false — boot should reconcile state without adding
+        // a history entry (issue #207 item 3).
+        await tryEnterPointModeIfNeeded({ pushHistory: false });
     }
 
     return "active";


### PR DESCRIPTION
Closes #207. Four small, independent fixes from the #203 retrospective Codex review (cluster A).

## Items

### #207 item 4 — low-altitude-without-`mode=point` round-trip

**Problem**: #203's early URL write can produce URLs like `alt=8000` *without* `mode=point` if the user copies during a pending point-mode transition. Boot only force-entered point mode when the URL had `mode=point`, so the round-trip landed in cluster mode at low altitude.

**Fix**: boot also enters point mode when `ih.alt < ENTER_POINT_ALT`, regardless of `ih.mode`. `tryEnterPointModeIfNeeded()` already short-circuits above the threshold, so cluster deep-links are unaffected.

### #207 item 6 — `h3` hashchange null-result asymmetry

**Problem**: when `fetchClusterByH3(state.h3)` returned null in the hashchange handler, the UI was cleared but `viewer._globeState.selectedH3` was left set to the invalid value. Boot path already cleared it on the same condition.

**Fix**: hashchange null branch now sets `selectedH3 = null` to match boot, preventing `buildHash()` from re-emitting invalid H3.

### #207 item 8 — selection state with search-result flights

**Problem**: search-result row clicks flew the camera but didn't update selection. The URL captured at flight settle (via #205's `moveEnd` listener) carried whatever prior `selectedPid` / `selectedH3` was set, misrepresenting the user's actual view.

**Fix**: 
- Row click now sets `selectedPid` to the clicked sample's pid (treats click as an explicit selection, matching on-globe sample clicks).
- Auto-flight to first result on world-scope searches clears prior selection (treats auto-pan as a nudge, not an explicit selection — user clicks a specific row to establish a new selection).

### #207 item 3 — boot/hash hydration shouldn't grow history

**Problem**: `tryEnterPointModeIfNeeded()` called `enterPointMode()` with default `pushHistory`, so boot would `pushState` a history entry every time.

**Fix**: threaded `opts.pushHistory` through the helper; boot call site passes `{ pushHistory: false }`. Camera-handler call sites keep the default (`pushState`) since those are user-driven movements where adding history is intentional.

## Verification

- `tests/playwright/url_roundtrip_investigation.js` — all 6 iterations green on localhost
- One-off test: URL `#v=1&lat=35.0150&lng=33.7000&alt=8000` (low alt, NO mode param) now enters point mode in a fresh tab and shows the real 23k count (combination of #206 + #207 item 4).

## Risks

- **Item 4 broadens boot's point-mode entry condition.** Previously only `ih.mode === 'point'` triggered the explicit boot call; now altitude does too. Cluster deep-links above `ENTER_POINT_ALT` are unchanged (short-circuit). A bookmarked URL with stale `mode=cluster` and low altitude will now enter point mode at boot — but that's the correct behavior given the altitude is the more authoritative state.
- **Item 8 row-click selection.** Setting `selectedPid` from a search-result click is a small UX change: the URL now reflects the searched-for sample as selected. The clicked sample's full sample card hydration is not part of this PR — that requires more data than the search-result row carries. Tracked as a possible follow-up if the lack of side-panel hydration is jarring.
- **Item 3 history avoidance.** Boot no longer adds a history entry on point-mode entry. Users navigating away and using back will now go to the previous page rather than a "stuck on this page in cluster mode" intermediate state. Net win, no obvious regression.
- **Tests don't cover items 6 and 8 directly.** They're tracked in #209 (test coverage expansion). The fixes are small enough that code review covers them.

## Test plan

- [x] url_roundtrip_investigation.js all 6 green
- [x] Low-alt no-mode URL enters point mode (verified manually)
- [ ] Manual smoke on deploy preview: 
  - Cyprus deep-link → pan small → copy URL → paste → matches (regression check for #203 + #205)
  - URL with low alt but no `mode=point` → enters point mode (item 4)
  - Hash to invalid h3 → URL cleans up (item 6)
  - Search result click → URL reflects pid (item 8)
- [ ] Codex review (recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)