### PR TITLE
hotfix: VIEWPORT_PAD_FACTOR must be OJS cell syntax, not const

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -747,7 +747,10 @@ function facetFilterSQL() {
 // stat (issue #221 round 2) all expand the raw view rectangle by this
 // factor so the three surfaces agree on a single "in view" predicate.
 // Pass 0 (or undefined) for exact-viewport semantics (area search).
-const VIEWPORT_PAD_FACTOR = 0.3;
+// OJS cell syntax (bare `name = value`); `const` here would not bind
+// the name into the OJS module scope and would break every dependent
+// cell (issue #223 quick-fix).
+VIEWPORT_PAD_FACTOR = 0.3
 
 // Return the viewer's current view rectangle, optionally padded in each
 // direction by `padFactor × span`, normalized into [-180, 180] longitude


### PR DESCRIPTION
## Hotfix for production breakage from PR #222

PR #222 introduced \`const VIEWPORT_PAD_FACTOR = 0.3;\` at the top of an \`{ojs}\` block. OJS does not bind \`const\`/\`let\`/\`var\` declarations into the module scope — names are exposed to other cells only via \`name = value\` cell syntax (or \`function name() {}\`). Because the broken cell sat at the head of the OJS block, every dependent cell failed with errors like:

- \`RuntimeError: applyQueryToFacetFilters is not defined\`
- \`RuntimeError: updatePhaseMsg is not defined\`
- \`RuntimeError: updateSamples is not defined\`

The live explorer page (https://isamples.org/explorer.html) was unusable.

**Fix**: \`VIEWPORT_PAD_FACTOR = 0.3\` (OJS cell syntax). 1-line change.

## Test plan

- [ ] https://isamples.org/explorer.html loads with all cells evaluating
- [ ] Cluster-mode count parity (the actual #221 round-2 fix) works as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)