### PR TITLE
explorer: show sample points over the heatmap in point mode

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -2570,14 +2570,25 @@ zoomWatcher = {
 
     // Single source of truth for marker-layer visibility (#233 phase 3).
     //
-    // Cluster dots (h3Points) and individual sample points (samplePoints)
-    // are mutually exclusive with the heatmap overlay. When the heatmap is
-    // on it IS the density view, so painting the cluster dots on top of it
-    // produces the dots-vs-hotspots disagreement RY flagged 2026-05-27 —
-    // two layers telling contradictory spatial stories at once. Rule:
-    //   heatmap on  ⇒ both marker collections hidden (heatmap stands alone)
-    //   heatmap off ⇒ show whichever collection the altitude-driven mode
-    //                 calls for (cluster→h3Points, point→samplePoints)
+    // The heatmap interacts differently with the two marker layers:
+    //
+    //   * Cluster dots (h3Points) DO contradict the heatmap. Both are
+    //     aggregate/density views, so painting cluster dots over the heatmap
+    //     produces the dots-vs-hotspots disagreement RY flagged 2026-05-27 —
+    //     two layers telling contradictory spatial stories at once. So cluster
+    //     dots stay hidden whenever the heatmap is on.
+    //
+    //   * Individual sample points (samplePoints) do NOT contradict it: they
+    //     are exact per-sample locations, which COMPLEMENT the density overlay
+    //     (heatmap = where it's dense, dots = the actual samples there). So at
+    //     sample resolution (point mode) we show the sample dots on top of the
+    //     heatmap rather than hiding them. (loadViewportSamples() already runs
+    //     under heatmap in point mode, so they stay loaded and pan-fresh — this
+    //     just unhides them.)
+    //
+    // Rule:
+    //   cluster mode → h3Points shown only when heatmap OFF
+    //   point mode   → samplePoints shown always (heatmap on or off)
     // Aside from the one-time initializer (samplePoints starts hidden at
     // creation), this is the ONLY place that writes `.show` on the two
     // collections. Call it from every site that flips the mode or the
@@ -2586,7 +2597,7 @@ zoomWatcher = {
         const heat = heatmapEnabled();
         const mode = getMode();
         viewer.h3Points.show = !heat && mode === 'cluster';
-        viewer.samplePoints.show = !heat && mode === 'point';
+        viewer.samplePoints.show = mode === 'point';
     }
 
     // --- Mode transitions ---


### PR DESCRIPTION
## What

When the heatmap is on **and** you're zoomed to sample resolution (point mode),
show the individual sample points on top of the heatmap instead of hiding them.

## Why

#242 made the heatmap mutually exclusive with **both** marker layers. That's
correct for **cluster dots** — they're an aggregate/density view, so painting
them over the heatmap gives the dots-vs-hotspots contradiction flagged
2026-05-27. But **individual sample points** are exact per-sample locations that
*complement* the density overlay (heatmap = where it's dense, dots = the actual
samples there), so hiding them at sample zoom loses useful detail.

New rule in `applyLayerVisibility()` (the single marker-visibility control point):

| | cluster zoom | sample zoom (point mode) |
|---|---|---|
| heatmap **off** | cluster dots | sample dots |
| heatmap **on** | *(nothing — heatmap alone)* | **sample dots over heatmap** ← new |

## Scope

One-line logic change (`viewer.samplePoints.show = mode === 'point'`) plus an
expanded rationale comment. No other paths needed:

- `loadViewportSamples()` already runs under heatmap in point mode (moveEnd
  handler calls it unconditionally), so the dots are loaded and stay pan-fresh —
  this just unhides them.
- The heatmap is a Cesium `SingleTileImageryProvider` on `imageryLayers` (globe
  surface), so sample primitives render *on top* of it.

`quarto render explorer.qmd` passes. Built on top of #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
