### PR TITLE
explorer: be honest that the samples table is not filtered by free-text search (#247)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -2156,9 +2156,27 @@ tableView = {
 
     function summaryText() {
         if (totalRows == null) return 'Counting samples...';
-        if (totalRows === 0) return 'No samples match the current filters.';
+        // Honesty fix (#247): when a free-text search is committed, the
+        // table still reflects ONLY the viewport + source/facet filters —
+        // the search term is NOT a table predicate (pre-A1; see #234 Step
+        // 4 / axis A1). Disclose that explicitly and point to the side
+        // panel, instead of claiming these rows "match the current filters"
+        // (which after a search-fly can be e.g. 43,803 GEOME mollusks for a
+        // "bucchero" search). `__explorerActiveSearch` is maintained by
+        // doSearch; null when no search is committed. setMeta uses
+        // textContent, so the term needs no HTML-escaping here.
+        const activeSearch = (typeof window !== 'undefined') ? window.__explorerActiveSearch : null;
+        if (totalRows === 0) {
+            return activeSearch
+                ? `No samples in this map view and current non-search filters. Search results for "${activeSearch}" are shown in the panel →`
+                : 'No samples match the current filters.';
+        }
         const total = totalRows.toLocaleString();
-        return `${total} sample${totalRows === 1 ? '' : 's'} match the current filters.`;
+        const plural = totalRows === 1 ? '' : 's';
+        if (activeSearch) {
+            return `${total} sample${plural} in this map view and current non-search filters. Search results for "${activeSearch}" are shown in the panel →`;
+        }
+        return `${total} sample${plural} match the current filters.`;
     }
 
     async function refreshAll() {
@@ -3846,12 +3864,41 @@ zoomWatcher = {
         const term = searchInput.value.trim();
         if (!term || term.length < 2) {
             searchResults.textContent = 'Type at least 2 characters';
+            // Honesty fix (#247): the samples-table meta line keys off this
+            // flag. An empty / too-short submit means no committed search, so
+            // clear it and refresh the table to revert to the plain "match
+            // the current filters" copy.
+            if (typeof window !== 'undefined') {
+                window.__explorerActiveSearch = null;
+                window.refreshSamplesTable?.();
+            }
             writeQueryState();
             persistSearchScope(effectiveScope);
             return;
         }
         writeQueryState();
         persistSearchScope(effectiveScope);
+        // Honesty fix (#247): record the committed search term so the
+        // samples-table meta line can disclose that the table reflects the
+        // map view + source/facet filters only — NOT this search. Free-text
+        // search is not yet a table/globe predicate (pre-A1; see #234 Step
+        // 4). Set at fire-time (independent of result success) so the meta is
+        // honest the moment the search commits.
+        if (typeof window !== 'undefined') window.__explorerActiveSearch = term;
+        // Refresh the table now so the meta copy updates immediately. World-
+        // scope searches fly the camera (moveEnd → refreshAll covers it), but
+        // area-scope searches do NOT move the camera, so without this nudge
+        // the meta would stay stale until the next interaction. Triggers the
+        // SAME refreshAll that moveEnd/filter-change already use (no new query
+        // shape); pageGen dedups against the fly-triggered refresh.
+        if (typeof window !== 'undefined') window.refreshSamplesTable?.();
+        // Shared, prominent + sticky search-results heading, reused by the
+        // success / zero-result / error paths so the side panel ALWAYS
+        // reflects the committed search the table meta points at ("…shown in
+        // the panel →"). z-index keeps it above scrolled rows. term is the
+        // user's own input, rendered as-is to match the prior heading.
+        const searchHeadingHTML = (suffix) =>
+            `<h4 class="search-results-heading" style="position: sticky; top: 0; z-index: 1; margin: 0 0 6px; padding: 6px 8px; background: #e3f2fd; color: #1565c0; border-radius: 4px;">Search results: "${term}"${suffix}</h4>`;
         searchResults.textContent = effectiveScope === 'area'
             ? 'Searching selected areas...'
             : 'Searching entire world...';
@@ -4021,6 +4068,13 @@ zoomWatcher = {
             resultsCount = results.length;
             if (results.length === 0) {
                 searchResults.textContent = `No results for "${term}"`;
+                // Honesty fix (#247): the table meta points "→ panel", so the
+                // panel must reflect THIS (empty) search rather than whatever
+                // it showed before. Without this, a zero-result search left
+                // stale prior content under a pointer claiming otherwise.
+                const sampEl0 = document.getElementById('samplesSection');
+                if (sampEl0) sampEl0.innerHTML = searchHeadingHTML(' (0)')
+                    + '<div class="empty-state" style="padding: 8px;">No samples matched this search.</div>';
                 return;
             }
 
@@ -4039,7 +4093,9 @@ zoomWatcher = {
             // Show results in the samples panel
             const sampEl = document.getElementById('samplesSection');
             if (sampEl) {
-                let h = `<h4>Search: "${term}" (${results.length})</h4>`;
+                // Prominent + sticky heading via the shared helper (see its
+                // definition above). No page/camera scroll — heading only.
+                let h = searchHeadingHTML(` (${results.length})`);
                 for (const s of results) {
                     const color = SOURCE_COLORS[s.source] || '#666';
                     const name = SOURCE_NAMES[s.source] || s.source;
@@ -4217,6 +4273,12 @@ zoomWatcher = {
                 console.error("Search failed:", err);
                 searchResults.textContent = `Search error: ${err.message}`;
                 errorMessage = err.message || String(err);
+                // Honesty fix (#247): keep the side panel consistent with the
+                // table meta's "→ panel" pointer on failure too, instead of
+                // leaving stale results under a pointer that now lies.
+                const sampElErr = document.getElementById('samplesSection');
+                if (sampElErr) sampElErr.innerHTML = searchHeadingHTML('')
+                    + '<div class="empty-state" style="padding: 8px;">Search failed — please try again.</div>';
             }
         } finally {
             performance.mark(markEnd);


### PR DESCRIPTION
## What

Interim **honesty fix** for #247: free-text search is not yet a filter on the main samples table. After a search the camera flies and the table fills with whatever is in the new viewport — e.g. searching **`bucchero`** (Etruscan pottery) flies to Tuscany and the table then shows **43,803 GEOME marine mollusks** while the meta line claims they *"match the current filters."* The actual search results sit in the side panel.

This PR makes the UI **honest about what the table is showing**. It does **not** change any SQL / query / filter behavior — the real fix (search as a global filter across table/globe/counts) is **#234 Step 4 / axis A1**, deferred because it touches every count surface and may want the FTS substrate (#168–172) first for scale. See the analysis + Claude⇄Codex consensus in #247.

## Changes (all in `explorer.qmd`)

- **`summaryText()`** — when a search is committed, the table meta now reads e.g.
  > *"43,803 samples in this map view and current non-search filters. Search results for "bucchero" are shown in the panel →"*

  instead of *"43,803 samples match the current filters."* The "non-search filters" wording deliberately marks this as **pre-A1** behavior (per Codex review) so it doesn't quietly redefine what A1 will mean. No active search → unchanged copy.
- **`doSearch()`** — maintains `window.__explorerActiveSearch` (committed term, or `null` on empty/too-short submit) as the cross-OJS-cell signal `summaryText()` reads, and nudges `window.refreshSamplesTable?.()` after commit/clear so the meta updates even for area-scope searches that don't move the camera.
- **Side panel** — the search-results heading is now prominent + **sticky** (within `#samplesSection`'s own scroll box; **no page/camera scroll**), so it reads unmistakably as the search results the meta points at. A shared heading helper now also paints the **zero-result** and **error** panel states, so the "→ panel" pointer is never left pointing at stale/empty content.

## Verification

- `quarto render explorer.qmd` clean; `git diff --check` clean.
- Live on rdhyee staging (canonical repro URL): `__explorerActiveSearch="bucchero"`, search telemetry `error:null` / 50 of 2,693, side panel shows the 50 real Poggio Civitate hits under the sticky heading, no console errors.
- Table-meta count is gated only on the (pre-existing, cold-cache-slow) `samples_map_lite` fetch; the honesty string is deterministic given the committed-search flag, which is confirmed set.

**Staging:** https://rdhyee.github.io/isamplesorg.github.io/explorer.html?search=bucchero&sources=OPENCONTEXT%2CGEOME%2CSMITHSONIAN#v=1&lat=40.8958&lng=5.2905&alt=3048966

## Provenance

Claude; **Codex 2-round review** — round 1 reached the ship-ad-hoc-fix-now / A1-later consensus on #247; round 2 reviewed this diff and caught that the active-search flag stayed set on zero-result/error searches (the panel pointer would lie), now fixed by painting those panel states + the refresh nudge. Empirically verified on staging.

Closes #247 (interim); real fix tracked under #234 Step 4 / A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
