### PR TITLE
explorer: remove duplicate sidebar search box (#266)

### DIFF
--- a/EXPLORER_STATE.md
+++ b/EXPLORER_STATE.md
@@ -29,13 +29,13 @@ citations.
 
 | field | owner | default | URL repr | hydration site | write-back trigger | validation | notes |
 |-------|-------|---------|----------|----------------|--------------------|------------|-------|
-| `search` | DOM `#sampleSearch` value (mirrored to `#sampleSearchSidebar`) | omitted | raw string | `applyQueryToSearch()` at start of `phase1` (hydrates both inputs) | `writeQueryState()` called from `doSearch()` | trim only; min 2 chars enforced at search time, not in URL | written even on no-result searches |
+| `search` | DOM `#sampleSearch` value | omitted | raw string | `applyQueryToSearch()` at start of `phase1` | `writeQueryState()` called from `doSearch()` | trim only; min 2 chars enforced at search time, not in URL | written even on no-result searches. The mirrored `#sampleSearchSidebar` input was removed in #266 |
 | `sources` | DOM `#sourceFilter` checkboxes | omitted (= all 4 checked) | CSV of `SOURCE_VALUES` ∩ user-checked | `applyQueryToSourceFilter()` at start of `phase1` (`:938`) | `writeQueryState()` from source filter `change` (`:1620`) | filtered by `SOURCE_VALUES` allowlist (`:407`); param removed when all 4 checked (`:449`) | empty (zero checked) renders as `&sources=` and yields `1=0` predicate (`:379`) |
 | `material` | DOM `#materialFilterBody` checkboxes | omitted (= no filter) | CSV of full URIs | `applyQueryToFacetFilters()` at end of `facetFilters` (`:1061`) | `writeQueryState()` from `handleFacetFilterChange` (`:1642`) | none — checkbox `value` already constrained by render | empty checked set ⇒ param removed (`:459`) |
 | `context` | DOM `#contextFilterBody` checkboxes | omitted | CSV of full URIs | same as `material` | same as `material` | none | same |
 | `object_type` | DOM `#objectTypeFilterBody` checkboxes | omitted | CSV of full URIs | same as `material` | same as `material` | none | same |
 | ~~`view`~~ | _removed in mockup-v1 (#200)_ | — | — | — | — | — | The Globe/Table toggle is gone — the samples table is now permanent below the globe. `writeQueryState()` does `params.delete('view')` to canonicalize legacy bookmarks. See §6 "Mockup-v1 addendum" |
-| `search_scope` | local closure `_searchScope` in `zoomWatcher` | omitted (= `world`) | `area` only; absent ⇒ world | `_searchScope` hydrated at top of `zoomWatcher` from `params.get('search_scope')` | `persistSearchScope()` from `doSearch()` and button clicks | exact match `'area'` | sidebar `#sampleSearchSidebar` Enter always submits `world`, never `area` — see §6 mockup-v1 addendum |
+| `search_scope` | local closure `_searchScope` in `zoomWatcher` | omitted (= `world`) | `area` only; absent ⇒ world | `_searchScope` hydrated at top of `zoomWatcher` from `params.get('search_scope')` | `persistSearchScope()` from `doSearch()` and button clicks | exact match `'area'` | (the sidebar search input that always submitted `world` was removed in #266) |
 | `page` | inner closure `let page = 0` in `tableView` | not in URL | — | — | resets to 0 on `refreshTable()`; ±1 on prev/next | clamped to `[0, totalPages-1]` | **#163 item 6** — table page is intentionally not URL state today; if/when added, must coexist with the cross-filter contract below |
 | `perf` | — (read-only feature flag) | omitted | `1` to enable | `perfPanel` cell reads (`:1921-1922`) | never written | `=== '1'` exact match | never round-tripped; safe to add other tail params |
 
@@ -99,12 +99,12 @@ predates the store-on-`viewer` pattern and isn't worth migrating.
 | `.zero` on `.facet-row` | "value has zero count under current filters" styling | `applyFacetCounts()` (`:565`) | CSS only | derived; do not read |
 | `.disabled` on `#sourceFilter .legend-item` | unchecked source visual | `updateSourceLegendState()` (`:395-400`) | CSS only | derived from checkbox `checked`; do not read |
 
-DOM input elements (the four facet checkbox bodies + `#sampleSearch` +
-`#sampleSearchSidebar`) are the **source of truth** for
-`getActiveSources()`, `getCheckedValues()`, and the search input. SQL
-builders read `#sampleSearch` directly each call. `#sampleSearchSidebar`
-is kept in lock-step with `#sampleSearch` via a two-way `input`-event
-mirror (see §6 mockup-v1 addendum). The `#maxSamples` input and the
+DOM input elements (the four facet checkbox bodies + `#sampleSearch`)
+are the **source of truth** for `getActiveSources()`,
+`getCheckedValues()`, and the search input. SQL builders read
+`#sampleSearch` directly each call. (The mirrored `#sampleSearchSidebar`
+input was removed in #266 — `#sampleSearch` is the only search box;
+the historical mirror design is in §6.) The `#maxSamples` input and the
 `getTableMaxSamples()` / `clampTableMaxSamples()` helpers were removed
 in the table v2 follow-up — the samples table now paginates server-side
 via DuckDB `LIMIT/OFFSET` instead of fetching up to 25K rows up-front.
@@ -375,7 +375,9 @@ base-layer picker dropdown wins z-stack (`z-index: 1100` vs overlay's
 `1000`).
 
 **M-1B — Sidebar open-text search input that mirrors the in-map one.**
-A second input `#sampleSearchSidebar` lives at the top of `.side-panel`.
+*(Removed in #266 — the duplicate sidebar box confused users; `#sampleSearch`
+is now the only search input. Kept for historical context:)*
+A second input `#sampleSearchSidebar` lived at the top of `.side-panel`.
 Two-way `input`-event mirror keeps both inputs in lock-step as a single
 logical query term:
 

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -216,17 +216,6 @@ format:
             padding: 4px 8px;
         }
     }
-    .sidebar-search { display: flex; flex-direction: column; gap: 4px; }
-    .sidebar-search input {
-        width: 100%;
-        padding: 7px 10px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        font-size: 13px;
-        outline: none;
-    }
-    .sidebar-search input:focus { border-color: #1565c0; box-shadow: 0 0 0 2px rgba(21,101,192,0.15); }
-    .sidebar-search-hint { font-size: 11px; color: #888; }
     .side-panel {
         display: flex;
         flex-direction: column;
@@ -652,10 +641,6 @@ Circle size = log(sample count). Color = dominant data source.
 </div>
 <div class="side-panel">
 <div id="activeSearchChipHost" class="filter-chip-host" hidden></div>
-<div class="panel-section sidebar-search">
-<input type="text" id="sampleSearchSidebar" placeholder="Search samples (press Enter to search globally)" aria-label="Search samples globally" />
-<div class="sidebar-search-hint">Enter searches the entire world. Use the in-map controls for area-limited search.</div>
-</div>
 <div class="panel-section">
 <div class="filter-section stats-disclosure">
 <div class="filter-header" role="button" tabindex="0" aria-expanded="false" aria-controls="statsPanelBody" onclick="const body = this.nextElementSibling; const open = body.style.display === 'none'; body.style.display = open ? 'block' : 'none'; this.setAttribute('aria-expanded', open ? 'true' : 'false'); this.querySelector('span').textContent = open ? '▾' : '▸';" onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); this.click(); }">
@@ -865,13 +850,11 @@ function applyQueryToSourceFilter() {
 // See docs/site_libs/quarto-search/quarto-search.js.
 function applyQueryToSearch() {
     const input = document.getElementById('sampleSearch');
-    const sidebarInput = document.getElementById('sampleSearchSidebar');
-    if (!input && !sidebarInput) return;
+    if (!input) return;
     const params = new URLSearchParams(location.search);
     const q = params.get('search');
     if (q != null) {
-        if (input) input.value = q;
-        if (sidebarInput) sidebarInput.value = q;
+        input.value = q;
     }
 }
 
@@ -4356,8 +4339,6 @@ zoomWatcher = {
         // Same clear path as an empty search submit, without entering doSearch().
         _searchSeq++;
         if (searchInput) searchInput.value = '';
-        const sidebarInput = document.getElementById('sampleSearchSidebar');
-        if (sidebarInput) sidebarInput.value = '';
         if (searchResults) searchResults.textContent = '';
         await clearSearchFilter();
         await applySearchFilterChange();
@@ -4952,8 +4933,6 @@ zoomWatcher = {
         // Mutual exclusivity: a committed concept filter OWNS search_pids, so
         // clear the free-text box (and its sidebar mirror) before building.
         if (searchInput) searchInput.value = '';
-        const sidebarInput = document.getElementById('sampleSearchSidebar');
-        if (sidebarInput) sidebarInput.value = '';
 
         if (searchResults) searchResults.textContent = 'Filtering by concept…';
 
@@ -5145,29 +5124,8 @@ zoomWatcher = {
         }
     });
 
-    // Sidebar open-text search (M-1B). Mirrors #sampleSearch so there's one
-    // logical query term with two input chrome. Enter on sidebar always
-    // submits world scope — typed-text-from-sidebar implies "find anywhere".
-    // The mirror guards against feedback loops by comparing values before
-    // setting; setting .value does not fire 'input' so a simple guard suffices.
-    const searchInputSidebar = document.getElementById('sampleSearchSidebar');
-    if (searchInputSidebar && searchInput) {
-        searchInputSidebar.addEventListener('input', () => {
-            if (searchInput.value !== searchInputSidebar.value) {
-                searchInput.value = searchInputSidebar.value;
-            }
-        });
-        searchInput.addEventListener('input', () => {
-            if (searchInputSidebar.value !== searchInput.value) {
-                searchInputSidebar.value = searchInput.value;
-            }
-        });
-    }
-    if (searchInputSidebar) searchInputSidebar.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229) {
-            doSearch('world');
-        }
-    });
+    // (#266) Sidebar search box removed — the in-map #sampleSearch overlay is
+    // the single canonical search input. The former sidebar mirror is gone.
 
     // #248 Flavor A boot: a `described-by=<concept-uri>` deep link commits the
     // concept filter. It WINS over `search=` if a hand-crafted URL carries both

--- a/tests/playwright/explorer-map-overlay.spec.js
+++ b/tests/playwright/explorer-map-overlay.spec.js
@@ -291,21 +291,19 @@ test.describe('Map search overlay — Cesium toolbar coexistence (#200 / M-1A)',
     expect(hash).toContain(`pid=${encodeURIComponent(pid)}`);
   });
 
-  test('sidebar search input mirrors in-map search input', async ({ page }) => {
+  test('sidebar search input is gone; in-map search is the only search box (#266)', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto(explorerUrl(), {
       waitUntil: 'domcontentloaded',
       timeout: 60000,
     });
     await page.waitForSelector('#sampleSearch', { timeout: 30000 });
-    await page.waitForSelector('#sampleSearchSidebar', { timeout: 10000 });
 
     await waitForBootReady(page);
 
-    await page.locator('#sampleSearchSidebar').fill('pottery');
-    await expect(page.locator('#sampleSearch')).toHaveValue('pottery');
-
-    await page.locator('#sampleSearch').fill('basalt');
-    await expect(page.locator('#sampleSearchSidebar')).toHaveValue('basalt');
+    // #266: the duplicate sidebar search box was removed — exactly one
+    // search input should exist, and it's the in-map one.
+    await expect(page.locator('#sampleSearchSidebar')).toHaveCount(0);
+    await expect(page.locator('#sampleSearch')).toHaveCount(1);
   });
 });


### PR DESCRIPTION
Fixes #266.

The Explorer had two visible search boxes: the in-map overlay (`#sampleSearch`) and a sidebar mirror (`#sampleSearchSidebar`). They shared one logical query, but two boxes read as two independent searches and confused users.

**Change:** remove the sidebar input + its CSS, the bidirectional mirror wiring, and three defensive value-sync one-liners. The in-map overlay stays the single source of truth for both world and area search — no functionality lost.

---
*— 🤖 rbotyee (RY's bot). RY skimmed; the bot did the work. Ping @rdhyee.*