### PR TITLE
#320: front-page caveat for the two not-yet-ingested showcase specimens

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -31,7 +31,7 @@ page-layout: full
 
 :::
 
-*Each image links to its record at the source repository. Two of these are also in the iSamples collection and open directly in our globe — the [fossil coral](/explorer.html#pid=IGSN:IEGIL000C&v=1) and the [askoi](/explorer.html#pid=ark:/28722/r2p24/vdm_19600211&v=1) — with the coral flying to the Cayman Islands and the askoi to Murlo, Italy.*
+*Each image links to its record at the source repository. Two of these are also in the iSamples collection and open directly in our globe — the [fossil coral](/explorer.html#pid=IGSN:IEGIL000C&v=1) and the [askoi](/explorer.html#pid=ark:/28722/r2p24/vdm_19600211&v=1) — with the coral flying to the Cayman Islands and the askoi to Murlo, Italy. The diamond and the fish live at their home repositories for now; they'll join the iSamples collection in a future data update.*
 
 ::: {.callout-tip collapse="true"}
 ## What is iSamples?

--- a/index_alt.qmd
+++ b/index_alt.qmd
@@ -20,7 +20,7 @@ group="my-group"}](https://n2t.net/ark:28722/r2p24/vdm_19600211 "Red-figure asko
 
 :::
 
-*Each image links to its record at the source repository. Two of these are also in the iSamples collection and open directly in our globe — the [fossil coral](/explorer.html#pid=IGSN:IEGIL000C&v=1) and the [askoi](/explorer.html#pid=ark:/28722/r2p24/vdm_19600211&v=1) — with the coral flying to the Cayman Islands and the askoi to Murlo, Italy.*
+*Each image links to its record at the source repository. Two of these are also in the iSamples collection and open directly in our globe — the [fossil coral](/explorer.html#pid=IGSN:IEGIL000C&v=1) and the [askoi](/explorer.html#pid=ark:/28722/r2p24/vdm_19600211&v=1) — with the coral flying to the Cayman Islands and the askoi to Murlo, Italy. The diamond and the fish live at their home repositories for now; they'll join the iSamples collection in a future data update.*
 
 The Internet of Samples (iSamples) is a multi-disciplinary and multi-institutional project funded by the National Science Foundation to design, develop, and promote service infrastructure to uniquely, consistently, and conveniently identify material samples, record metadata about them, and persistently link them to other samples and derived digital content, including images, data, and publications.
 


### PR DESCRIPTION
> 🤖 **rbotyee** (Claude, operated by @rdhyee) — *Raymond's decision (2026-07-11):* caveat text is the accepted resolution for #320. *What I did:* one honest sentence added to the showcase line on both index pages (kept in sync per #321's convention).

Adds: *"The diamond and the fish live at their home repositories for now; they'll join the iSamples collection in a future data update."*

Text-only; @jkunze's images and links untouched. The optional supplementary-parquet idea stays parked on #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjnkWb4HpuLeDbYfzmY3X9